### PR TITLE
Port to Godot 4

### DIFF
--- a/addons/virtualcamera/Examples/ShakeExample.tscn
+++ b/addons/virtualcamera/Examples/ShakeExample.tscn
@@ -1,368 +1,367 @@
-[gd_scene load_steps=26 format=2]
+[gd_scene load_steps=31 format=3 uid="uid://d3klej7p2gr24"]
 
-[ext_resource path="res://addons/virtualcamera/VCameraBrain.gd" type="Script" id=1]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/Shake.gd" type="Script" id=2]
-[ext_resource path="res://addons/virtualcamera/VCameras/VCamera.gd" type="Script" id=3]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/BackForthMovement.gd" type="Script" id=4]
+[ext_resource type="Script" path="res://addons/virtualcamera/VCameraBrain.gd" id="1"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/Shake.gd" id="2"]
+[ext_resource type="Script" path="res://addons/virtualcamera/VCameras/VCamera.gd" id="3"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/BackForthMovement.gd" id="4"]
 
-[sub_resource type="ProceduralSky" id=1]
-sky_top_color = Color( 0.313726, 0.54902, 0.843137, 1 )
-sky_horizon_color = Color( 0.862745, 0.960784, 1, 1 )
-ground_bottom_color = Color( 0, 0, 0, 1 )
-ground_horizon_color = Color( 0.392157, 0.411765, 0.392157, 1 )
-sun_color = Color( 0.862745, 0.960784, 1, 1 )
-sun_latitude = 30.0
-sun_longitude = -150.0
-sun_angle_min = 2.0
-sun_angle_max = 30.0
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_qne8l"]
 
-[sub_resource type="Environment" id=2]
+[sub_resource type="Sky" id="Sky_popkt"]
+sky_material = SubResource("ProceduralSkyMaterial_qne8l")
+
+[sub_resource type="Environment" id="Environment_bqbg7"]
 background_mode = 2
-background_sky = SubResource( 1 )
-ambient_light_color = Color( 0.27451, 0.27451, 0.27451, 1 )
-ambient_light_sky_contribution = 0.1
-fog_enabled = true
-fog_color = Color( 0.392157, 0.411765, 0.392157, 0.117647 )
-fog_sun_color = Color( 0.901961, 0.784314, 0.431373, 0.117647 )
-fog_sun_amount = 0.3
-fog_depth_begin = 5.0
+sky = SubResource("Sky_popkt")
 
-[sub_resource type="Animation" id=23]
+[sub_resource type="Animation" id="23"]
 length = 0.001
 tracks/0/type = "value"
-tracks/0/path = NodePath("Player:translation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
+tracks/0/path = NodePath("Player:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [ Vector3( 0, 1, 0 ) ]
+"values": [Vector3(0, 1, 0)]
 }
 tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("Player:rotation_degrees")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [ Vector3( 0, 0, 0 ) ]
+"values": [Vector3(0, 0, 0)]
 }
 tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("Player/EyeLevel/BackForthMovement:strength_factor")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [ 1.0 ]
+"values": [1.0]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Train:translation")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
+tracks/3/path = NodePath("Train:position")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
 tracks/3/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [ Vector3( 0, 2, -10.5 ) ]
+"values": [Vector3(0, 2, -10.5)]
 }
 tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
 tracks/4/path = NodePath("Player/EyeLevel/BackForthMovement/HandCamShake/TraumaShake:intensity")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [ 0.0 ]
+"values": [0.0]
 }
 
-[sub_resource type="Animation" id=24]
+[sub_resource type="Animation" id="24"]
 resource_name = "TrainGoesBy"
 length = 20.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Player:translation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
+tracks/0/path = NodePath("Player:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 1, 1.3, 3.4, 4, 4.6, 7.7, 8 ),
-"transitions": PoolRealArray( 1, 2, 1, 1, 1, 1, 0.5, 1 ),
+"times": PackedFloat32Array(0, 1, 1.3, 3.4, 4, 4.6, 7.7, 8),
+"transitions": PackedFloat32Array(1, 2, 1, 1, 1, 1, 0.5, 1),
 "update": 0,
-"values": [ Vector3( 16, 1, 20 ), Vector3( 16, 1, 20 ), Vector3( 15.2667, 1, 19.4667 ), Vector3( 6.90123, 1, 13.3827 ), Vector3( 5.73877, 1, 11.4441 ), Vector3( 4.74324, 1, 9.81757 ), Vector3( 3.1, 1, -4.15 ), Vector3( 3, 1, -5 ) ]
+"values": [Vector3(16, 1, 20), Vector3(16, 1, 20), Vector3(15.2667, 1, 19.4667), Vector3(6.90123, 1, 13.3827), Vector3(5.73877, 1, 11.4441), Vector3(4.74324, 1, 9.81757), Vector3(3.1, 1, -4.15), Vector3(3, 1, -5)]
 }
 tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("Player:rotation_degrees")
 tracks/1/interp = 2
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0, 1, 3, 4.7, 7.8, 8.5, 9, 10.5 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
+"times": PackedFloat32Array(0, 1, 3, 4.7, 7.8, 8.5, 9, 10.5),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
 "update": 0,
-"values": [ Vector3( 0, 30, 0 ), Vector3( 0, 30, 0 ), Vector3( 0, 15, 0 ), Vector3( 0, -1.809, 0 ), Vector3( 0, -1.809, 0 ), Vector3( 0, -1.809, 0 ), Vector3( 0, -77.651, 0 ), Vector3( 0, 57.349, 0 ) ]
+"values": [Vector3(0, 30, 0), Vector3(0, 30, 0), Vector3(0, 15, 0), Vector3(0, -1.809, 0), Vector3(0, -1.809, 0), Vector3(0, -1.809, 0), Vector3(0, -77.651, 0), Vector3(0, 57.349, 0)]
 }
 tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("Player/EyeLevel/BackForthMovement:strength_factor")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0, 1, 1.2, 7.7, 8 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
+"times": PackedFloat32Array(0, 1, 1.2, 7.7, 8),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1),
 "update": 0,
-"values": [ 0.1, 0.1, 1.0, 1.0, 0.1 ]
+"values": [0.1, 0.1, 1.0, 1.0, 0.1]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Train:translation")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
+tracks/3/path = NodePath("Train:position")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
 tracks/3/keys = {
-"times": PoolRealArray( 0, 7.7, 16.9 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
+"times": PackedFloat32Array(0, 7.7, 16.9),
+"transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
-"values": [ Vector3( 60, 2, -10.5 ), Vector3( 60, 2, -10.5 ), Vector3( -200, 2, -10.5 ) ]
+"values": [Vector3(60, 2, -10.5), Vector3(60, 2, -10.5), Vector3(-200, 2, -10.5)]
 }
 tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
 tracks/4/path = NodePath("Player/EyeLevel/BackForthMovement/HandCamShake/TraumaShake:intensity")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 9.2, 9.5, 11.5 ),
-"transitions": PoolRealArray( 1, 1, 1, 1 ),
+"times": PackedFloat32Array(0, 9.2, 9.5, 11.5),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
-"values": [ 0.0, 0.0, 1.0, 0.0 ]
+"values": [0.0, 0.0, 1.0, 0.0]
 }
 
-[sub_resource type="CubeMesh" id=14]
-size = Vector3( 50, 2, 50 )
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_3775q"]
+_data = {
+"RESET": SubResource("23"),
+"TrainGoesBy": SubResource("24")
+}
 
-[sub_resource type="SpatialMaterial" id=4]
-albedo_color = Color( 0.392157, 0.72549, 0.392157, 1 )
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_cpk6i"]
+albedo_color = Color(0.392157, 0.72549, 0.392157, 1)
 roughness = 0.7
 
-[sub_resource type="CylinderMesh" id=5]
-top_radius = 0.5
-bottom_radius = 0.5
+[sub_resource type="BoxMesh" id="14"]
+size = Vector3(50, 2, 50)
 
-[sub_resource type="SpatialMaterial" id=11]
-albedo_color = Color( 0.333333, 0.254902, 0.372549, 1 )
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7u4bb"]
+albedo_color = Color(0.333333, 0.254902, 0.372549, 1)
 
-[sub_resource type="CylinderMesh" id=6]
+[sub_resource type="CylinderMesh" id="5"]
+
+[sub_resource type="CylinderMesh" id="6"]
 top_radius = 1.5
 bottom_radius = 1.5
 height = 1.0
 
-[sub_resource type="CylinderMesh" id=7]
+[sub_resource type="CylinderMesh" id="7"]
 top_radius = 0.75
 bottom_radius = 0.75
 height = 1.0
 
-[sub_resource type="CubeMesh" id=12]
-size = Vector3( 4, 4, 4 )
+[sub_resource type="BoxMesh" id="12"]
+size = Vector3(4, 4, 4)
 
-[sub_resource type="CubeMesh" id=15]
-size = Vector3( 50, 0.3, 0.3 )
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_w4tbw"]
+albedo_color = Color(0.333333, 0.254902, 0.372549, 1)
 
-[sub_resource type="SpatialMaterial" id=16]
-albedo_color = Color( 0.333333, 0.254902, 0.372549, 1 )
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_yrd0t"]
+albedo_color = Color(0.333333, 0.254902, 0.372549, 1)
 metallic = 1.0
 roughness = 0.1
 
-[sub_resource type="CubeMesh" id=17]
-size = Vector3( 1, 1, 1 )
+[sub_resource type="BoxMesh" id="15"]
+size = Vector3(50, 0.3, 0.3)
 
-[sub_resource type="SpatialMaterial" id=13]
-albedo_color = Color( 0.313726, 0.54902, 0.843137, 1 )
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_fre0u"]
+albedo_color = Color(0.333333, 0.254902, 0.372549, 1)
+metallic = 1.0
+roughness = 0.1
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_j88k0"]
+albedo_color = Color(0.313726, 0.54902, 0.843137, 1)
 roughness = 0.45
 
-[sub_resource type="CylinderMesh" id=18]
-top_radius = 0.5
-bottom_radius = 0.5
+[sub_resource type="BoxMesh" id="17"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7tleb"]
+albedo_color = Color(0.313726, 0.54902, 0.843137, 1)
+roughness = 0.45
+
+[sub_resource type="CylinderMesh" id="18"]
 height = 1.0
 
-[sub_resource type="CapsuleShape" id=19]
-radius = 0.5
+[sub_resource type="CapsuleShape3D" id="19"]
 
-[sub_resource type="CapsuleMesh" id=20]
-radius = 0.5
-
-[sub_resource type="SpatialMaterial" id=9]
-albedo_color = Color( 0.843137, 0.45098, 0.333333, 1 )
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_so4ej"]
+albedo_color = Color(0.843137, 0.45098, 0.333333, 1)
 roughness = 0.45
 
-[sub_resource type="OpenSimplexNoise" id=21]
-seed = 58668
-octaves = 2
+[sub_resource type="CapsuleMesh" id="20"]
 
-[sub_resource type="OpenSimplexNoise" id=22]
+[sub_resource type="FastNoiseLite" id="21"]
+seed = 58668
+fractal_octaves = 2
+
+[sub_resource type="FastNoiseLite" id="22"]
 seed = 127425
-octaves = 4
-persistence = 0.8
+fractal_octaves = 4
 
 [node name="SplitScreenExample" type="Node"]
 
 [node name="World" type="Node" parent="."]
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="World"]
-environment = SubResource( 2 )
+environment = SubResource("Environment_bqbg7")
 
-[node name="DirectionalLight" type="DirectionalLight" parent="World"]
-transform = Transform( 0.866025, 0.25, -0.433013, 0, 0.866025, 0.5, 0.5, -0.433012, 0.75, 0, 10, 0 )
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="World"]
+transform = Transform3D(0.866025, 0.25, -0.433013, 0, 0.866025, 0.5, 0.5, -0.433012, 0.75, 0, 10, 0)
 shadow_enabled = true
 
-[node name="VCameraBrain" type="Camera" parent="World"]
+[node name="VCameraBrain" type="Camera3D" parent="World"]
 process_priority = -1000
-transform = Transform( 0.597657, -0.0422151, 0.80064, -0.0121213, 0.998023, 0.0616707, -0.80166, -0.0465627, 0.595963, 3, 2.70499, -5 )
-script = ExtResource( 1 )
+transform = Transform3D(0.997905, 0.00326228, -0.0646261, 0.0013805, 0.997428, 0.0716659, 0.0646937, -0.0716049, 0.995333, 0, 2.72187, 0)
+fov = 70.0
+far = 100.0
+script = ExtResource("1")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="World"]
 autoplay = "TrainGoesBy"
-anims/RESET = SubResource( 23 )
-anims/TrainGoesBy = SubResource( 24 )
+libraries = {
+"": SubResource("AnimationLibrary_3775q")
+}
 
-[node name="Level" type="Spatial" parent="World"]
+[node name="Level" type="Node3D" parent="World"]
 
-[node name="Ground" type="MeshInstance" parent="World/Level"]
-mesh = SubResource( 14 )
+[node name="Ground" type="MeshInstance3D" parent="World/Level"]
+material_override = SubResource("StandardMaterial3D_cpk6i")
+mesh = SubResource("14")
 skeleton = NodePath("../..")
-material/0 = SubResource( 4 )
 
-[node name="Pillar1" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6.64687, 2, 5.30097 )
-mesh = SubResource( 5 )
+[node name="Pillar1" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.64687, 2, 5.30097)
+material_override = SubResource("StandardMaterial3D_7u4bb")
+mesh = SubResource("5")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Pillar2" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -22.8734, 2, -5.92979 )
-mesh = SubResource( 5 )
+[node name="Pillar2" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -22.8734, 2, -5.92979)
+material_override = SubResource("StandardMaterial3D_7u4bb")
+mesh = SubResource("5")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Pillar3" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -11.3295, 1.5, -17.139 )
-mesh = SubResource( 6 )
+[node name="Pillar3" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -11.3295, 1.5, -17.139)
+material_override = SubResource("StandardMaterial3D_7u4bb")
+mesh = SubResource("6")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Pillar4" type="MeshInstance" parent="World/Level/Pillar3"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5 )
-mesh = SubResource( 7 )
+[node name="Pillar4" type="MeshInstance3D" parent="World/Level/Pillar3"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5)
+material_override = SubResource("StandardMaterial3D_7u4bb")
+mesh = SubResource("7")
 skeleton = NodePath("../../..")
-material/0 = SubResource( 11 )
 
-[node name="Block1" type="MeshInstance" parent="World/Level"]
-transform = Transform( 0.965926, 0, 0.258819, 0, 1, 0, -0.258819, 0, 0.965926, -1.9649, 3, 14.0545 )
-mesh = SubResource( 12 )
+[node name="Block1" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(0.965926, 0, 0.258819, 0, 1, 0, -0.258819, 0, 0.965926, -1.9649, 3, 14.0545)
+material_override = SubResource("StandardMaterial3D_7u4bb")
+mesh = SubResource("12")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Block2" type="MeshInstance" parent="World/Level"]
-transform = Transform( 0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, -6.96492, 3, 0.0544901 )
-mesh = SubResource( 12 )
+[node name="Block2" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, -6.96492, 3, 0.0544901)
+material_override = SubResource("StandardMaterial3D_w4tbw")
+mesh = SubResource("12")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Block3" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, -1.73205, 0, 2, 0, 1.73205, 0, 1, 17.0351, 5, 0.0545006 )
-mesh = SubResource( 12 )
+[node name="Block3" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, -1.73205, 0, 2, 0, 1.73205, 0, 1, 17.0351, 5, 0.0545006)
+material_override = SubResource("StandardMaterial3D_7u4bb")
+mesh = SubResource("12")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Rail1" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.15, -12 )
-mesh = SubResource( 15 )
+[node name="Rail1" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.15, -12)
+material_override = SubResource("StandardMaterial3D_yrd0t")
+mesh = SubResource("15")
 skeleton = NodePath("../..")
-material/0 = SubResource( 16 )
 
-[node name="Rail2" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.15, -9 )
-mesh = SubResource( 15 )
+[node name="Rail2" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.15, -9)
+material_override = SubResource("StandardMaterial3D_fre0u")
+mesh = SubResource("15")
 skeleton = NodePath("../..")
-material/0 = SubResource( 16 )
 
-[node name="Train" type="Spatial" parent="World"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, -10.5 )
+[node name="Train" type="Node3D" parent="World"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, -10.5)
 
-[node name="Base" type="MeshInstance" parent="World/Train"]
-transform = Transform( 10, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0 )
-mesh = SubResource( 17 )
+[node name="Base" type="MeshInstance3D" parent="World/Train"]
+transform = Transform3D(10, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0)
+material_override = SubResource("StandardMaterial3D_j88k0")
+mesh = SubResource("17")
 skeleton = NodePath("../..")
-material/0 = SubResource( 13 )
 
-[node name="Cabin" type="MeshInstance" parent="World/Train"]
-transform = Transform( 5.28, 0, 0, 0, 3.12, 0, 0, 0, 3.3, 3, 2, 0 )
-mesh = SubResource( 17 )
+[node name="Cabin" type="MeshInstance3D" parent="World/Train"]
+transform = Transform3D(5.28, 0, 0, 0, 3.12, 0, 0, 0, 3.3, 3, 2, 0)
+material_override = SubResource("StandardMaterial3D_7tleb")
+mesh = SubResource("17")
 skeleton = NodePath("../..")
-material/0 = SubResource( 13 )
 
-[node name="Nose" type="MeshInstance" parent="World/Train"]
-transform = Transform( -1.31134e-07, -5, 0, 3, -2.18557e-07, 0, 0, 0, 3, -2, 1, 0 )
-mesh = SubResource( 18 )
+[node name="Nose" type="MeshInstance3D" parent="World/Train"]
+transform = Transform3D(-1.31134e-07, -5, 0, 3, -2.18557e-07, 0, 0, 0, 3, -2, 1, 0)
+material_override = SubResource("StandardMaterial3D_j88k0")
+mesh = SubResource("18")
 skeleton = NodePath("../..")
-material/0 = SubResource( 13 )
 
-[node name="Player" type="KinematicBody" parent="World"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0 )
+[node name="Player" type="CharacterBody3D" parent="World"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 
-[node name="CollisionShape" type="CollisionShape" parent="World/Player"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 1, 0 )
-shape = SubResource( 19 )
+[node name="CollisionShape3D" type="CollisionShape3D" parent="World/Player"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+shape = SubResource("19")
 
-[node name="MeshInstance" type="MeshInstance" parent="World/Player"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 1, 0 )
-mesh = SubResource( 20 )
-material/0 = SubResource( 9 )
+[node name="MeshInstance3D" type="MeshInstance3D" parent="World/Player"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+material_override = SubResource("StandardMaterial3D_so4ej")
+mesh = SubResource("20")
 
-[node name="EyeLevel" type="Spatial" parent="World/Player"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.7, 0 )
+[node name="EyeLevel" type="Node3D" parent="World/Player"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.7, 0)
 
-[node name="BackForthMovement" type="Spatial" parent="World/Player/EyeLevel"]
-transform = Transform( 1, 0, 1.78814e-07, 0, 1, 0, -1.78814e-07, 0, 1, 0, 0.00500011, 0 )
-script = ExtResource( 4 )
+[node name="BackForthMovement" type="Node3D" parent="World/Player/EyeLevel"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.0249133, 0)
+script = ExtResource("4")
 duration_forth = 0.4
 duration_back = 0.2
 ease_forth = 0.5
 ease_back = 2.0
-translate_by = Vector3( 0, 0.05, 0 )
+translate_by = Vector3(0, 0.05, 0)
 
-[node name="HandCamShake" type="Spatial" parent="World/Player/EyeLevel/BackForthMovement"]
-transform = Transform( 0.999947, 0.00859793, -0.00566972, -0.00858825, 0.999962, 0.0017305, 0.00568438, -0.00168172, 0.999982, 0, 0, 0 )
-script = ExtResource( 2 )
-noise = SubResource( 21 )
+[node name="HandCamShake" type="Node3D" parent="World/Player/EyeLevel/BackForthMovement"]
+transform = Transform3D(0.999992, -0.0038686, 0.000643593, 0.00386039, 0.999917, 0.0123013, -0.000691128, -0.0122987, 0.999924, 0, 0, 0)
+script = ExtResource("2")
+noise = SubResource("21")
 speed = 0.5
-rotation_strength = Vector3( 1, 1, 1 )
+rotation_strength = Vector3(1, 1, 1)
 
-[node name="TraumaShake" type="Spatial" parent="World/Player/EyeLevel/BackForthMovement/HandCamShake"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )
-script = ExtResource( 2 )
-noise = SubResource( 22 )
+[node name="TraumaShake" type="Node3D" parent="World/Player/EyeLevel/BackForthMovement/HandCamShake"]
+script = ExtResource("2")
+noise = SubResource("22")
 intensity = 0.0
-rotation_strength = Vector3( 15, 15, 15 )
+rotation_strength = Vector3(15, 15, 15)
 
-[node name="WalkingVCamera" type="Spatial" parent="World/Player/EyeLevel/BackForthMovement/HandCamShake/TraumaShake" groups=["vcamera"]]
+[node name="WalkingVCamera" type="Node3D" parent="World/Player/EyeLevel/BackForthMovement/HandCamShake/TraumaShake" groups=["vcamera"]]
 process_priority = -1000
-transform = Transform( 0.997874, 0.00742948, -0.064755, -0.0035656, 0.998217, 0.0595817, 0.0650822, -0.0592241, 0.996121, 0, 0, 0 )
-script = ExtResource( 3 )
+transform = Transform3D(0.997874, 0.00742948, -0.064755, -0.0035656, 0.998217, 0.0595817, 0.0650822, -0.0592241, 0.996121, 0, 0, 0)
+script = ExtResource("3")
 transition_time = 0.1

--- a/addons/virtualcamera/Examples/SplitScreenExample.tscn
+++ b/addons/virtualcamera/Examples/SplitScreenExample.tscn
@@ -1,247 +1,233 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=22 format=3 uid="uid://djyiwotrm124w"]
 
-[ext_resource path="res://addons/virtualcamera/VCameraBrain.gd" type="Script" id=1]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/UniformMovement/UniformRotation.gd" type="Script" id=2]
-[ext_resource path="res://addons/virtualcamera/VCameras/VCamera.gd" type="Script" id=3]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/Follow.gd" type="Script" id=4]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/LookAt.gd" type="Script" id=5]
+[ext_resource type="Script" path="res://addons/virtualcamera/VCameraBrain.gd" id="1"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/UniformMovement/UniformRotation.gd" id="2"]
+[ext_resource type="Script" path="res://addons/virtualcamera/VCameras/VCamera.gd" id="3"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/Follow.gd" id="4"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/LookAt.gd" id="5"]
 
-[sub_resource type="ProceduralSky" id=1]
-sky_top_color = Color( 0.313726, 0.54902, 0.843137, 1 )
-sky_horizon_color = Color( 0.862745, 0.960784, 1, 1 )
-ground_bottom_color = Color( 0, 0, 0, 1 )
-ground_horizon_color = Color( 0.392157, 0.411765, 0.392157, 1 )
-sun_color = Color( 0.862745, 0.960784, 1, 1 )
-sun_latitude = 30.0
-sun_longitude = -150.0
-sun_angle_min = 2.0
-sun_angle_max = 30.0
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_qne8l"]
 
-[sub_resource type="Environment" id=2]
+[sub_resource type="Sky" id="Sky_popkt"]
+sky_material = SubResource("ProceduralSkyMaterial_qne8l")
+
+[sub_resource type="Environment" id="Environment_fde4p"]
 background_mode = 2
-background_sky = SubResource( 1 )
-ambient_light_color = Color( 0.27451, 0.27451, 0.27451, 1 )
-ambient_light_sky_contribution = 0.1
-fog_enabled = true
-fog_color = Color( 0.392157, 0.411765, 0.392157, 0.117647 )
-fog_sun_color = Color( 0.901961, 0.784314, 0.431373, 0.117647 )
-fog_sun_amount = 0.3
-fog_depth_begin = 5.0
+sky = SubResource("Sky_popkt")
 
-[sub_resource type="SpatialMaterial" id=4]
-albedo_color = Color( 0.392157, 0.72549, 0.392157, 1 )
+[sub_resource type="StandardMaterial3D" id="4"]
+albedo_color = Color(0.392157, 0.72549, 0.392157, 1)
 roughness = 0.7
 
-[sub_resource type="SpatialMaterial" id=10]
-albedo_color = Color( 0.901961, 0.784314, 0.431373, 1 )
+[sub_resource type="StandardMaterial3D" id="10"]
+albedo_color = Color(0.901961, 0.784314, 0.431373, 1)
 
-[sub_resource type="CylinderMesh" id=5]
-top_radius = 0.5
-bottom_radius = 0.5
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_sqs0p"]
+albedo_color = Color(0.333333, 0.254902, 0.372549, 1)
 
-[sub_resource type="SpatialMaterial" id=11]
-albedo_color = Color( 0.333333, 0.254902, 0.372549, 1 )
+[sub_resource type="CylinderMesh" id="5"]
 
-[sub_resource type="CylinderMesh" id=6]
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_bswp4"]
+albedo_color = Color(0.333333, 0.254902, 0.372549, 1)
+
+[sub_resource type="CylinderMesh" id="6"]
 top_radius = 1.5
 bottom_radius = 1.5
 height = 1.0
 
-[sub_resource type="CylinderMesh" id=7]
+[sub_resource type="CylinderMesh" id="7"]
 top_radius = 0.75
 bottom_radius = 0.75
 height = 1.0
 
-[sub_resource type="CubeMesh" id=12]
-size = Vector3( 4, 4, 4 )
+[sub_resource type="BoxMesh" id="12"]
+size = Vector3(4, 4, 4)
 
-[sub_resource type="PrismMesh" id=8]
-size = Vector3( 2, 3, 0.3 )
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_kbdeg"]
+albedo_color = Color(0.333333, 0.254902, 0.372549, 1)
 
-[sub_resource type="SpatialMaterial" id=9]
-albedo_color = Color( 0.843137, 0.45098, 0.333333, 1 )
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_r6dwh"]
+albedo_color = Color(0.333333, 0.254902, 0.372549, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_21h1c"]
+albedo_color = Color(0.843137, 0.45098, 0.333333, 1)
 roughness = 0.45
 
-[sub_resource type="SpatialMaterial" id=13]
-albedo_color = Color( 0.313726, 0.54902, 0.843137, 1 )
+[sub_resource type="PrismMesh" id="8"]
+size = Vector3(2, 3, 0.3)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_77y2y"]
+albedo_color = Color(0.313726, 0.54902, 0.843137, 1)
 roughness = 0.45
 
 [node name="SplitScreenExample" type="Node"]
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-custom_constants/separation = 0
+theme_override_constants/separation = 0
 
-[node name="ViewportContainer1" type="ViewportContainer" parent="HBoxContainer"]
-margin_right = 512.0
-margin_bottom = 600.0
+[node name="ViewportContainer1" type="SubViewportContainer" parent="HBoxContainer"]
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch = true
 
-[node name="Viewport" type="Viewport" parent="HBoxContainer/ViewportContainer1"]
-size = Vector2( 512, 600 )
+[node name="SubViewport" type="SubViewport" parent="HBoxContainer/ViewportContainer1"]
 handle_input_locally = false
-render_target_update_mode = 3
-shadow_atlas_size = 1
+size = Vector2i(576, 648)
+render_target_update_mode = 4
 
-[node name="VCameraBrain" type="Camera" parent="HBoxContainer/ViewportContainer1/Viewport"]
+[node name="VCameraBrain" type="Camera3D" parent="HBoxContainer/ViewportContainer1/SubViewport"]
 process_priority = -1000
-transform = Transform( -1, 2.54818e-08, -1.4883e-07, 0, 0.985658, 0.168758, 1.50996e-07, 0.168758, -0.985658, 13, 0.482905, -3.98861 )
+transform = Transform3D(-1, 2.54818e-08, -1.4883e-07, 0, 0.985658, 0.168758, 1.50996e-07, 0.168758, -0.985658, 13, 0.482905, -3.98861)
 fov = 90.0
-script = ExtResource( 1 )
+far = 100.0
+script = ExtResource("1")
 target_group = "vcamera_1"
 
-[node name="ViewportContainer2" type="ViewportContainer" parent="HBoxContainer"]
-margin_left = 512.0
-margin_right = 1024.0
-margin_bottom = 600.0
+[node name="ViewportContainer2" type="SubViewportContainer" parent="HBoxContainer"]
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch = true
 
-[node name="Viewport" type="Viewport" parent="HBoxContainer/ViewportContainer2"]
-size = Vector2( 512, 600 )
+[node name="SubViewport" type="SubViewport" parent="HBoxContainer/ViewportContainer2"]
 handle_input_locally = false
-render_target_update_mode = 3
-shadow_atlas_size = 1
+size = Vector2i(576, 648)
+render_target_update_mode = 4
 
-[node name="VCameraBrain" type="Camera" parent="HBoxContainer/ViewportContainer2/Viewport"]
+[node name="VCameraBrain" type="Camera3D" parent="HBoxContainer/ViewportContainer2/SubViewport"]
 process_priority = -1000
-transform = Transform( -1, 3.36599e-08, -1.47196e-07, 0, 0.974837, 0.22292, 1.50996e-07, 0.22292, -0.974837, 17, 0.714761, -4.00029 )
+transform = Transform3D(-1, 3.36599e-08, -1.47196e-07, 0, 0.974837, 0.22292, 1.50996e-07, 0.22292, -0.974837, 17, 0.714761, -4.00029)
 fov = 90.0
-script = ExtResource( 1 )
+far = 100.0
+script = ExtResource("1")
 target_group = "vcamera_2"
 
 [node name="World" type="Node" parent="."]
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="World"]
-environment = SubResource( 2 )
+environment = SubResource("Environment_fde4p")
 
-[node name="DirectionalLight" type="DirectionalLight" parent="World"]
-transform = Transform( 0.866025, 0.25, -0.433013, 0, 0.866025, 0.5, 0.5, -0.433012, 0.75, 0, 10, 0 )
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="World"]
+transform = Transform3D(0.866025, 0.25, -0.433013, 0, 0.866025, 0.5, 0.5, -0.433012, 0.75, 0, 10, 0)
 shadow_enabled = true
 
-[node name="Level" type="Spatial" parent="World"]
+[node name="Level" type="Node3D" parent="World"]
 
-[node name="Ground" type="CSGCombiner" parent="World/Level"]
+[node name="Ground" type="CSGCombiner3D" parent="World/Level"]
 
-[node name="CSGBox" type="CSGBox" parent="World/Level/Ground"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2, 0 )
-width = 60.0
-height = 4.0
-depth = 60.0
-material = SubResource( 4 )
+[node name="CSGBox3D" type="CSGBox3D" parent="World/Level/Ground"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2, 0)
+size = Vector3(60, 4, 60)
+material = SubResource("4")
 
-[node name="CSGTorus" type="CSGTorus" parent="World/Level/Ground"]
-transform = Transform( 1, 0, 0, 0, 0.4, 0, 0, 0, 1, 0, 0, 0 )
+[node name="CSGTorus3D" type="CSGTorus3D" parent="World/Level/Ground"]
+transform = Transform3D(1, 0, 0, 0, 0.4, 0, 0, 0, 1, 0, 0, 0)
 operation = 2
 inner_radius = 10.0
 outer_radius = 20.0
 sides = 32
-material = SubResource( 10 )
+material = SubResource("10")
 
-[node name="Pillar1" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6.64687, 1, 5.30097 )
-mesh = SubResource( 5 )
+[node name="Pillar1" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.64687, 1, 5.30097)
+material_override = SubResource("StandardMaterial3D_sqs0p")
+mesh = SubResource("5")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Pillar2" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -20.8734, 0.999999, 3.07021 )
-mesh = SubResource( 5 )
+[node name="Pillar2" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20.8734, 0.999999, 3.07021)
+material_override = SubResource("StandardMaterial3D_bswp4")
+mesh = SubResource("5")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Pillar3" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -11.3295, 0.5, 18.861 )
-mesh = SubResource( 6 )
+[node name="Pillar3" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -11.3295, 0.5, 18.861)
+material_override = SubResource("StandardMaterial3D_sqs0p")
+mesh = SubResource("6")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Pillar4" type="MeshInstance" parent="World/Level/Pillar3"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5 )
-mesh = SubResource( 7 )
+[node name="Pillar4" type="MeshInstance3D" parent="World/Level/Pillar3"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5)
+material_override = SubResource("StandardMaterial3D_sqs0p")
+mesh = SubResource("7")
 skeleton = NodePath("../../..")
-material/0 = SubResource( 11 )
 
-[node name="Block1" type="MeshInstance" parent="World/Level"]
-transform = Transform( 0.965926, 0, 0.258819, 0, 1, 0, -0.258819, 0, 0.965926, 19.0351, 2, 22.0545 )
-mesh = SubResource( 12 )
+[node name="Block1" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(0.965926, 0, 0.258819, 0, 1, 0, -0.258819, 0, 0.965926, 19.0351, 2, 22.0545)
+material_override = SubResource("StandardMaterial3D_sqs0p")
+mesh = SubResource("12")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Block2" type="MeshInstance" parent="World/Level"]
-transform = Transform( 0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, -5.96492, 2, -2.94551 )
-mesh = SubResource( 12 )
+[node name="Block2" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, -5.96492, 2, -2.94551)
+material_override = SubResource("StandardMaterial3D_kbdeg")
+mesh = SubResource("12")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Block3" type="MeshInstance" parent="World/Level"]
-transform = Transform( 1, 0, -1.73205, 0, 2, 0, 1.73205, 0, 1, 17.0351, 4, -18.9455 )
-mesh = SubResource( 12 )
+[node name="Block3" type="MeshInstance3D" parent="World/Level"]
+transform = Transform3D(1, 0, -1.73205, 0, 2, 0, 1.73205, 0, 1, 17.0351, 4, -18.9455)
+material_override = SubResource("StandardMaterial3D_r6dwh")
+mesh = SubResource("12")
 skeleton = NodePath("../..")
-material/0 = SubResource( 11 )
 
-[node name="Players" type="Spatial" parent="World"]
+[node name="Players" type="Node3D" parent="World"]
 
-[node name="UniformRotation1" type="Spatial" parent="World/Players"]
-script = ExtResource( 2 )
-degrees_per_second = Vector3( 0, -26, 0 )
+[node name="UniformRotation1" type="Node3D" parent="World/Players"]
+script = ExtResource("2")
+degrees_per_second = Vector3(0, -26, 0)
 
-[node name="Player1" type="MeshInstance" parent="World/Players/UniformRotation1"]
-transform = Transform( 0.984808, -6.64073e-10, -0.173648, -0.173648, -7.5904e-09, -0.984808, -6.64073e-10, 1, -7.5904e-09, 13, -1.2, 0 )
-mesh = SubResource( 8 )
+[node name="Player1" type="MeshInstance3D" parent="World/Players/UniformRotation1"]
+transform = Transform3D(0.984808, -6.64073e-10, -0.173648, -0.173648, -7.5904e-09, -0.984808, -6.64073e-10, 1, -7.5904e-09, 13, -1.2, 0)
+material_override = SubResource("StandardMaterial3D_21h1c")
+mesh = SubResource("8")
 skeleton = NodePath("../../../..")
-material/0 = SubResource( 9 )
 
-[node name="UniformRotation2" type="Spatial" parent="World/Players"]
-script = ExtResource( 2 )
-degrees_per_second = Vector3( 0, -22, 0 )
+[node name="UniformRotation2" type="Node3D" parent="World/Players"]
+script = ExtResource("2")
+degrees_per_second = Vector3(0, -22, 0)
 
-[node name="Player2" type="MeshInstance" parent="World/Players/UniformRotation2"]
-transform = Transform( 0.984808, 6.64073e-10, 0.173648, 0.173648, -7.5904e-09, -0.984808, 6.64073e-10, 1, -7.5904e-09, 17, -1.2, 0 )
-mesh = SubResource( 8 )
+[node name="Player2" type="MeshInstance3D" parent="World/Players/UniformRotation2"]
+transform = Transform3D(0.984808, 6.64073e-10, 0.173648, 0.173648, -7.5904e-09, -0.984808, 6.64073e-10, 1, -7.5904e-09, 17, -1.2, 0)
+material_override = SubResource("StandardMaterial3D_77y2y")
+mesh = SubResource("8")
 skeleton = NodePath("../../../..")
-material/0 = SubResource( 13 )
 
-[node name="VCameras" type="Spatial" parent="World"]
+[node name="VCameras" type="Node3D" parent="World"]
 
-[node name="Follow1" type="Spatial" parent="World/VCameras"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 13, 0.482905, -3.98861 )
-script = ExtResource( 4 )
+[node name="Follow1" type="Node3D" parent="World/VCameras"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13, 0.482905, -3.98861)
+script = ExtResource("4")
 target_path = NodePath("../../Players/UniformRotation1/Player1")
-offset = Vector3( 0, 2, 0 )
-min_distance = 2.0
-max_distance = 5.0
+offset = Vector3(0, 2, 0)
 
-[node name="LookAt1" type="Spatial" parent="World/VCameras/Follow1"]
-transform = Transform( -1, 2.54818e-08, -1.4883e-07, 0, 0.985658, 0.168758, 1.50996e-07, 0.168758, -0.985658, 0, 0, 0 )
-script = ExtResource( 5 )
+[node name="LookAt1" type="Node3D" parent="World/VCameras/Follow1"]
+transform = Transform3D(-1, 2.54818e-08, -1.4883e-07, 0, 0.985658, 0.168758, 1.50996e-07, 0.168758, -0.985658, 0, 0, 0)
+script = ExtResource("5")
 look_at_target = NodePath("../../../Players/UniformRotation1/Player1")
-look_at_offset = Vector3( 0, 1, 0 )
+look_at_offset = Vector3(0, 1, 0)
 
-[node name="VCamera1" type="Spatial" parent="World/VCameras/Follow1/LookAt1" groups=["vcamera", "vcamera_1"]]
+[node name="VCamera1" type="Node3D" parent="World/VCameras/Follow1/LookAt1" groups=["vcamera", "vcamera_1"]]
 process_priority = -1000
-script = ExtResource( 3 )
+script = ExtResource("3")
 fov = 90.0
 
-[node name="Follow2" type="Spatial" parent="World/VCameras"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 17, 0.714761, -4.00029 )
-script = ExtResource( 4 )
+[node name="Follow2" type="Node3D" parent="World/VCameras"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 17, 0.714761, -4.00029)
+script = ExtResource("4")
 target_path = NodePath("../../Players/UniformRotation2/Player2")
-offset = Vector3( 0, 2, 0 )
-min_distance = 2.0
-max_distance = 5.0
+offset = Vector3(0, 2, 0)
 
-[node name="LookAt2" type="Spatial" parent="World/VCameras/Follow2"]
-transform = Transform( -1, 3.36599e-08, -1.47196e-07, 0, 0.974837, 0.22292, 1.50996e-07, 0.22292, -0.974837, 0, 0, 0 )
-script = ExtResource( 5 )
+[node name="LookAt2" type="Node3D" parent="World/VCameras/Follow2"]
+transform = Transform3D(-1, 3.36599e-08, -1.47196e-07, 0, 0.974837, 0.22292, 1.50996e-07, 0.22292, -0.974837, 0, 0, 0)
+script = ExtResource("5")
 look_at_target = NodePath("../../../Players/UniformRotation2/Player2")
-look_at_offset = Vector3( 0, 1, 0 )
+look_at_offset = Vector3(0, 1, 0)
 
-[node name="VCamera2" type="Spatial" parent="World/VCameras/Follow2/LookAt2" groups=["vcamera", "vcamera_2"]]
+[node name="VCamera2" type="Node3D" parent="World/VCameras/Follow2/LookAt2" groups=["vcamera", "vcamera_2"]]
 process_priority = -1000
-script = ExtResource( 3 )
+script = ExtResource("3")
 fov = 90.0

--- a/addons/virtualcamera/Examples/VCameraExample.tscn
+++ b/addons/virtualcamera/Examples/VCameraExample.tscn
@@ -1,19 +1,19 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=20 format=3 uid="uid://raeu2n6trnvt"]
 
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/UserInput/Orbiter.gd" type="Script" id=1]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/LookAtGroup.gd" type="Script" id=2]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/Follow.gd" type="Script" id=3]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/LookAt.gd" type="Script" id=4]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/Shake.gd" type="Script" id=5]
-[ext_resource path="res://addons/virtualcamera/VCameraBrain.gd" type="Script" id=6]
-[ext_resource path="res://addons/virtualcamera/TransformModifiers/UniformMovement/UniformRotation.gd" type="Script" id=7]
-[ext_resource path="res://addons/virtualcamera/VCameras/VCamera.gd" type="Script" id=8]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/UserInput/Orbiter.gd" id="1"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/LookAtGroup.gd" id="2"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/Follow.gd" id="3"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/LookAt.gd" id="4"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/Shake.gd" id="5"]
+[ext_resource type="Script" path="res://addons/virtualcamera/VCameraBrain.gd" id="6"]
+[ext_resource type="Script" path="res://addons/virtualcamera/TransformModifiers/UniformMovement/UniformRotation.gd" id="7"]
+[ext_resource type="Script" path="res://addons/virtualcamera/VCameras/VCamera.gd" id="8"]
 
-[sub_resource type="GDScript" id=6]
+[sub_resource type="GDScript" id="6"]
 resource_name = "CameraChanger"
-script/source = "extends Spatial
+script/source = "extends Node3D
 
-onready var vcameras : Array = get_tree().get_nodes_in_group(\"vcamera\")
+@onready var vcameras : Array = get_tree().get_nodes_in_group(\"vcamera\")
 var index = 0
 
 func _process(delta: float) -> void:
@@ -24,28 +24,38 @@ func _process(delta: float) -> void:
 		vcameras[index].priority = 30
 "
 
-[sub_resource type="CubeMesh" id=1]
-size = Vector3( 2, 0, 2 )
+[sub_resource type="BoxMesh" id="1"]
+size = Vector3(2, 0, 2)
 
-[sub_resource type="CylinderMesh" id=2]
-top_radius = 0.5
-bottom_radius = 0.5
+[sub_resource type="CylinderMesh" id="2"]
 
-[sub_resource type="CylinderMesh" id=3]
+[sub_resource type="CylinderMesh" id="3"]
 top_radius = 1.5
 bottom_radius = 1.5
 height = 1.0
 
-[sub_resource type="CylinderMesh" id=4]
+[sub_resource type="CylinderMesh" id="4"]
 top_radius = 0.75
 bottom_radius = 0.75
 height = 1.0
 
-[sub_resource type="SphereMesh" id=5]
-radius = 0.5
-height = 1.0
+[sub_resource type="SphereMesh" id="5"]
 
-[sub_resource type="GDScript" id=7]
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_qne8l"]
+
+[sub_resource type="Sky" id="Sky_popkt"]
+sky_material = SubResource("ProceduralSkyMaterial_qne8l")
+
+[sub_resource type="Environment" id="Environment_7cysg"]
+background_mode = 2
+sky = SubResource("Sky_popkt")
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_o3o6t"]
+seed = 889483742
+fractal_octaves = 4
+fractal_gain = 0.8
+
+[sub_resource type="GDScript" id="7"]
 script/source = "extends Label
 
 func _process(delta:float):
@@ -53,159 +63,142 @@ func _process(delta:float):
 	var brain = $\"../../../VCameraBrain\"
 	if brain && brain.last_active_vcamera != null:
 		camera_name = brain.last_active_vcamera.name
-	text = \"Current Camera: \" + camera_name
+	text = \"Current Camera3D: \" + camera_name
 "
 
-[node name="VCameraExample" type="Spatial"]
-script = SubResource( 6 )
+[node name="VCameraExample" type="Node3D"]
+script = SubResource("6")
 
 [node name="Level" type="Node" parent="."]
 
-[node name="DirectionalLight" type="DirectionalLight" parent="Level"]
-transform = Transform( 0.742981, 0.175351, -0.645934, 0, 0.965071, 0.261987, 0.669312, -0.194651, 0.71703, 0, 3.5684, 0 )
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="Level"]
+transform = Transform3D(0.742981, 0.175351, -0.645934, 0, 0.965071, 0.261987, 0.669312, -0.194651, 0.71703, 0, 3.5684, 0)
+shadow_enabled = true
 
-[node name="Ground" type="MeshInstance" parent="Level"]
-transform = Transform( 15, 0, 0, 0, 1, 0, 0, 0, 15, 0, 0, 0 )
-mesh = SubResource( 1 )
-material/0 = null
+[node name="Ground" type="MeshInstance3D" parent="Level"]
+transform = Transform3D(15, 0, 0, 0, 1, 0, 0, 0, 15, 0, 0, 0)
+mesh = SubResource("1")
 
-[node name="Pillar1" type="MeshInstance" parent="Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 1, 0 )
-mesh = SubResource( 2 )
-material/0 = null
+[node name="Pillar1" type="MeshInstance3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 1, 0)
+mesh = SubResource("2")
 
-[node name="Pillar2" type="MeshInstance" parent="Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 1, -2 )
-mesh = SubResource( 2 )
-material/0 = null
+[node name="Pillar2" type="MeshInstance3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 1, -2)
+mesh = SubResource("2")
 
-[node name="Pillar3" type="MeshInstance" parent="Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0.5, -2 )
-mesh = SubResource( 3 )
-material/0 = null
+[node name="Pillar3" type="MeshInstance3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0.5, -2)
+mesh = SubResource("3")
 
-[node name="Pillar4" type="MeshInstance" parent="Level/Pillar3"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5 )
-mesh = SubResource( 4 )
+[node name="Pillar4" type="MeshInstance3D" parent="Level/Pillar3"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, -0.5)
+mesh = SubResource("4")
 skeleton = NodePath("../..")
-material/0 = null
 
-[node name="UniformRotation" type="Spatial" parent="Level"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0 )
-script = ExtResource( 7 )
-degrees_per_second = Vector3( 0, 20, 0 )
+[node name="UniformRotation" type="Node3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+script = ExtResource("7")
+degrees_per_second = Vector3(0, 20, 0)
 
-[node name="Character" type="MeshInstance" parent="Level/UniformRotation"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 0, 0 )
-mesh = SubResource( 5 )
+[node name="Character" type="MeshInstance3D" parent="Level/UniformRotation"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 0, 0)
+mesh = SubResource("5")
 skeleton = NodePath("../../..")
-material/0 = null
 
-[node name="VCameraBrain" type="Camera" parent="."]
+[node name="VCameraBrain" type="Camera3D" parent="."]
 process_priority = -1000
-transform = Transform( 0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, -4, 2.4, 2 )
-fov = 70.0167
-script = ExtResource( 6 )
+transform = Transform3D(0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, -4, 2.4, 2)
+environment = SubResource("Environment_7cysg")
+fov = 70.0
+far = 100.0
+script = ExtResource("6")
 
-[node name="StaticVCamera" type="Spatial" parent="."]
+[node name="StaticVCamera" type="Node3D" parent="." groups=["vcamera"]]
 process_priority = -1000
-transform = Transform( 0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, -4, 2.4, 2 )
-script = ExtResource( 8 )
+transform = Transform3D(0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, 0.707107, -4, 2.4, 2)
+script = ExtResource("8")
 
-[node name="StaticVCamera2" type="Spatial" parent="."]
+[node name="StaticVCamera2" type="Node3D" parent="." groups=["vcamera"]]
 process_priority = -1000
-transform = Transform( 0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 3, 2.4, 2 )
-script = ExtResource( 8 )
+transform = Transform3D(0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 3, 2.4, 2)
+script = ExtResource("8")
 fov = 100.0
 
-[node name="Shake" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.746, 4 )
-script = ExtResource( 5 )
-shake_strength_rotation = Vector3( 10, 10, 0 )
+[node name="Shake" type="Node3D" parent="."]
+script = ExtResource("5")
+noise = SubResource("FastNoiseLite_o3o6t")
 
-[node name="ShakyVCamera" type="Spatial" parent="Shake"]
+[node name="ShakyVCamera" type="Node3D" parent="Shake" groups=["vcamera"]]
 process_priority = -1000
-script = ExtResource( 8 )
+script = ExtResource("8")
 fov = 90.0
 
-[node name="Follow1" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 1, 0 )
-script = ExtResource( 3 )
-follow_target = NodePath("../Level/UniformRotation/Character")
-follow_lerp_t = 0.9
+[node name="Follow1" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 1, 0)
+script = ExtResource("3")
 
-[node name="LookAt" type="Spatial" parent="Follow1"]
-transform = Transform( -1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, 0, 0, 0 )
-script = ExtResource( 4 )
-__meta__ = {
-"_editor_description_": "This LookAt places the children objects in the followed character's transformation space. This way translation is always relative to the character's movement."
-}
+[node name="LookAt" type="Node3D" parent="Follow1"]
+transform = Transform3D(-1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, 0, 0, 0)
+script = ExtResource("4")
 look_at_target = NodePath("../../Level/UniformRotation/Character")
 
-[node name="LookAt" type="Spatial" parent="Follow1/LookAt"]
-transform = Transform( 1, 0, -0.000495781, 0, 1, 0, 0.000495781, 0, 1, -0.00247526, 2, 4.99225 )
-script = ExtResource( 4 )
+[node name="LookAt" type="Node3D" parent="Follow1/LookAt"]
+transform = Transform3D(1, 0, -0.000495781, 0, 1, 0, 0.000495781, 0, 1, -0.00247526, 2, 4.99225)
+script = ExtResource("4")
 look_at_target = NodePath("../../../Level/UniformRotation/Character")
-look_at_offset = Vector3( 0, 2, 0 )
+look_at_offset = Vector3(0, 2, 0)
 
-[node name="FollowerVCamera" type="Spatial" parent="Follow1/LookAt/LookAt"]
+[node name="FollowerVCamera" type="Node3D" parent="Follow1/LookAt/LookAt" groups=["vcamera"]]
 process_priority = -1000
-transform = Transform( 1, 0, 0, 0, 1, -2.98023e-08, 0, 5.96046e-08, 1, 0, 0, 0 )
-script = ExtResource( 8 )
+transform = Transform3D(1, 0, 0, 0, 1, -2.98023e-08, 0, 5.96046e-08, 1, 0, 0, 0)
+script = ExtResource("8")
 fov = 60.0
 
-[node name="Follow2" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 1, 0 )
-script = ExtResource( 3 )
-follow_target = NodePath("../Level/UniformRotation/Character")
-follow_lerp_t = 0.9
+[node name="Follow2" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 1, 0)
+script = ExtResource("3")
 
-[node name="Orbiter" type="Spatial" parent="Follow2"]
-transform = Transform( -1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, 0, 0, 0 )
-script = ExtResource( 1 )
+[node name="Orbiter" type="Node3D" parent="Follow2"]
+transform = Transform3D(-1, 0, -1.50996e-07, 0, 1, 0, 1.50996e-07, 0, -1, 0, 0, 0)
+script = ExtResource("1")
 lerp_speed = 0.2
-orbit_radii = Vector3( 0.5, 3, 1 )
-orbit_heights = Vector3( 1.5, 1, -0.5 )
+orbit_radii = Vector3(0.5, 3, 1)
+orbit_heights = Vector3(1.5, 1, -0.5)
 
-[node name="LookAt" type="Spatial" parent="Follow2/Orbiter"]
-transform = Transform( -1, -5.61559e-08, -1.40165e-07, 1.77636e-15, 0.928271, -0.371904, 1.50996e-07, -0.371904, -0.928271, 0, 0, 0 )
-script = ExtResource( 4 )
+[node name="LookAt" type="Node3D" parent="Follow2/Orbiter"]
+transform = Transform3D(-1, -5.61559e-08, -1.40165e-07, 1.77636e-15, 0.928271, -0.371904, 1.50996e-07, -0.371904, -0.928271, 0, 0, 0)
+script = ExtResource("4")
 look_at_target = NodePath("../../../Level/UniformRotation/Character")
-look_at_offset = Vector3( 0, 1, 0 )
+look_at_offset = Vector3(0, 1, 0)
 
-[node name="OrbiterVCamera" type="Spatial" parent="Follow2/Orbiter/LookAt"]
+[node name="OrbiterVCamera" type="Node3D" parent="Follow2/Orbiter/LookAt" groups=["vcamera"]]
 process_priority = -1000
-transform = Transform( 1, 0, 0, 0, 1, -2.98023e-08, 0, 5.96046e-08, 1, 0, 0, 0 )
-script = ExtResource( 8 )
+transform = Transform3D(1, 0, 0, 0, 1, -2.98023e-08, 0, 5.96046e-08, 1, 0, 0, 0)
+script = ExtResource("8")
 
-[node name="LookAtGroup" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 5.20606, 4.12931, 3.09742 )
-script = ExtResource( 2 )
-look_at_targets = [ NodePath("../Level/Pillar1"), NodePath("../Level/Pillar2"), NodePath("../Level/UniformRotation/Character") ]
-target_weights = [ Vector3( 1, 1, 1 ), Vector3( 1, 1, 1 ), Vector3( 1, 1, 1 ) ]
+[node name="LookAtGroup" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.20606, 4.12931, 3.09742)
+script = ExtResource("2")
+look_at_targets = Array[NodePath]([NodePath("../Level/Pillar1"), NodePath("../Level/Pillar2"), NodePath("../Level/UniformRotation/Character")])
+target_weights = Array[Vector3]([Vector3(1, 1, 1), Vector3(1, 1, 1), Vector3(1, 1, 1)])
 
-[node name="GroupTrackerVCamera" type="Spatial" parent="LookAtGroup"]
+[node name="GroupTrackerVCamera" type="Node3D" parent="LookAtGroup" groups=["vcamera"]]
 process_priority = -1000
-script = ExtResource( 8 )
+script = ExtResource("8")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
-margin_right = 14.0
-margin_bottom = 14.0
+offset_right = 14.0
+offset_bottom = 14.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
-margin_left = 7.0
-margin_top = 7.0
-margin_right = 244.0
-margin_bottom = 39.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="PanelContainer/VBoxContainer"]
-margin_right = 237.0
-margin_bottom = 14.0
+layout_mode = 2
 text = "Press space to change virtual camera"
 
 [node name="CurrentCameraName" type="Label" parent="PanelContainer/VBoxContainer"]
-margin_top = 18.0
-margin_right = 237.0
-margin_bottom = 32.0
-text = "Current Camera: WWWWW"
-script = SubResource( 7 )
+layout_mode = 2
+text = "Current Camera3D: WWWWW"
+script = SubResource("7")

--- a/addons/virtualcamera/Helpers/PropertyListGenerator.gd
+++ b/addons/virtualcamera/Helpers/PropertyListGenerator.gd
@@ -1,4 +1,4 @@
-extends Reference
+extends RefCounted
 
 var properties : Array = []
 var instance
@@ -58,7 +58,8 @@ func append_number_range(name : String, min_value : float, max_value : float, st
 	var new_property = {
 		name = name,
 		type = typeof(instance.get(name)),
-		hint = PROPERTY_HINT_EXP_RANGE if exponential else PROPERTY_HINT_RANGE,
+		#hint = PROPERTY_HINT_EXP_RANGE if exponential else PROPERTY_HINT_RANGE, 
+		hint = PROPERTY_HINT_RANGE, # PROPERTY_HINT_EXP_RANGE and PROPERTY_HINT_RANGE are now one and the same
 		hint_string = hint_string,
 		usage = property_usage
 	}
@@ -71,7 +72,7 @@ func append_enum(name : String, of_enum : Dictionary, allow_other_values : bool 
 		return
 	
 	match typeof(instance.get(name)):
-		TYPE_INT, TYPE_REAL:
+		TYPE_INT, TYPE_FLOAT:
 			allow_other_values = false
 		TYPE_STRING:
 			pass
@@ -130,7 +131,7 @@ func append_enum_flags(name : String, of_enum : Dictionary, property_usage = PRO
 	properties.append(new_property)
 
 func append_category(begins_with : String, name : String = ""):
-	if not name:
+	if name.is_empty():
 		name = begins_with.capitalize()
 	
 	properties.append({

--- a/addons/virtualcamera/TransformModifiers/BackForthMovement.gd
+++ b/addons/virtualcamera/TransformModifiers/BackForthMovement.gd
@@ -1,21 +1,21 @@
-tool
+@tool
 extends "res://addons/virtualcamera/TransformModifiers/TransformModifier.gd"
 
 class_name BackForthMovement
 
-export(float, 0.0, 60.0) var duration_forth : float = 1.0
-export(float, 0.0, 60.0) var duration_back : float = 1.0
-export(float, 0.0, 120.0) var time_offset : float = 0.0
+@export_range(0.0,60.0) var duration_forth : float = 1.0 # (float, 0.0, 60.0)
+@export_range(0.0,60.0) var duration_back : float = 1.0 # (float, 0.0, 60.0)
+@export_range(0.0,120.0) var time_offset : float = 0.0 # (float, 0.0, 120.0)
 
-export(float, EASE) var ease_forth : float = -2.0
-export(float, EASE) var ease_back : float = -2.0
+@export_exp_easing var ease_forth : float = -2.0 # (float, EASE)
+@export_exp_easing var ease_back : float = -2.0 # (float, EASE)
 
-export(float, 0.1, 10.0) var time_factor : float = 1.0
-export(float, 0.1, 1.0) var strength_factor : float = 1.0
+@export_range(0.1,10.0) var time_factor : float = 1.0 # (float, 0.1, 10.0)
+@export_range(0.1,1.0) var strength_factor : float = 1.0 # (float, 0.1, 1.0)
 
-export var translate_by : Vector3 = Vector3.ZERO
-export var rotate_degrees : Vector3 = Vector3.ZERO
-export var scale_by : Vector3 = Vector3.ONE
+@export var translate_by : Vector3 = Vector3.ZERO
+@export var rotate_degrees : Vector3 = Vector3.ZERO
+@export var scale_by : Vector3 = Vector3.ONE
 
 var time : float = time_offset
 
@@ -32,17 +32,17 @@ func _physics_process(delta : float):
 		t = 1 - ease(t, ease_back)
 	
 	var initial_position : Vector3
-	var new_rotation := Quat.IDENTITY
-	var parent = get_parent() as Spatial
+	var new_rotation := Quaternion.IDENTITY
+	var parent = get_parent() as Node3D
 	if parent:
 		initial_position = parent.global_transform.origin
-		new_rotation = parent.global_transform.basis.get_rotation_quat()
+		new_rotation = parent.global_transform.basis.get_rotation_quaternion()
 	
 	global_transform.origin = initial_position + translate_by * t * strength_factor
 	
-	new_rotation *= Quat(Vector3.RIGHT, t * deg2rad(rotate_degrees.x))
-	new_rotation *= Quat(Vector3.UP, t * deg2rad(rotate_degrees.y))
-	new_rotation *= Quat(Vector3.BACK, t * deg2rad(rotate_degrees.z))
+	new_rotation *= Quaternion(Vector3.RIGHT, t * deg_to_rad(rotate_degrees.x))
+	new_rotation *= Quaternion(Vector3.UP, t * deg_to_rad(rotate_degrees.y))
+	new_rotation *= Quaternion(Vector3.BACK, t * deg_to_rad(rotate_degrees.z))
 	global_transform.basis = Basis(new_rotation)
 	
-	scale = Vector3.ONE.linear_interpolate(scale_by, t)
+	scale = Vector3.ONE.lerp(scale_by, t)

--- a/addons/virtualcamera/TransformModifiers/Follow.gd
+++ b/addons/virtualcamera/TransformModifiers/Follow.gd
@@ -12,20 +12,20 @@ var target : Node3D
 @export var offset : Vector3 = Vector3.ZERO
 
 # Distance that Follow isn't allowed to go any closer to target.
-@export_range(0.0, 2048.0, , "exp") var min_distance : float = 1.0 # (float, EXP, 0.0, 2048.0)
+@export_range(0.0, 2048.0) var min_distance : float = 1.0 # (float, EXP, 0.0, 2048.0)
 # Softer margin starting from min_distance outwards which pushes Follow gently away from target.
-@export_range(0.0, 1024.0, , "exp") var min_distance_push_margin : float = 1.0 # (float, EXP, 0.0, 1024.0)
+@export_range(0.0, 1024.0) var min_distance_push_margin : float = 1.0 # (float, EXP, 0.0, 1024.0)
 # Strength at which Follow will be pushed away if it were at min_distance away.
-@export_range(0.0, 100.0, , "exp") var min_distance_push_strength : float = 10.0 # (float, EXP, 0.0, 100.0)
+@export_range(0.0, 100.0) var min_distance_push_strength : float = 10.0 # (float, EXP, 0.0, 100.0)
 # How pushing strength will lessen when approaching end of margin.
 @export_exp_easing var min_distance_push_easing : float = 2.0 # (float, EASE)
 
 # Distance that Follow isn't allowed to go any farther away from target.
-@export_range(0.0, 2048.0, , "exp") var max_distance : float = 3.0 # (float, EXP, 0.0, 2048.0)
+@export_range(0.0, 2048.0) var max_distance : float = 3.0 # (float, EXP, 0.0, 2048.0)
 # Softer margin starting from max_distance inwards which pulls Follow gently towards target.
-@export_range(0.0, 1024.0, , "exp") var max_distance_push_margin : float = 1.0 # (float, EXP, 0.0, 1024.0)
+@export_range(0.0, 1024.0) var max_distance_push_margin : float = 1.0 # (float, EXP, 0.0, 1024.0)
 # Strength at which Follow will be pulled if it were at max_distance away.
-@export_range(0.0, 100.0, , "exp") var max_distance_push_strength : float = 10.0 # (float, EXP, 0.0, 100.0)
+@export_range(0.0, 100.0) var max_distance_push_strength : float = 10.0 # (float, EXP, 0.0, 100.0)
 # How pushing strength will lessen when approaching end of margin.
 @export_exp_easing var max_distance_push_easing : float = 2.0 # (float, EASE)
 

--- a/addons/virtualcamera/TransformModifiers/Follow.gd
+++ b/addons/virtualcamera/TransformModifiers/Follow.gd
@@ -1,49 +1,49 @@
-tool
+@tool
 extends "res://addons/virtualcamera/TransformModifiers/TransformModifier.gd"
 # Follows target keeping set distance and offset.
 class_name Follow
 
 # Target to follow (settable from editor).
-export var target_path : NodePath
+@export var target_path : NodePath
 # Target to follow (settable runtime).
-var target : Spatial
+var target : Node3D
 
 # Offset to apply from target's position in global coordinates.
-export var offset : Vector3 = Vector3.ZERO
+@export var offset : Vector3 = Vector3.ZERO
 
 # Distance that Follow isn't allowed to go any closer to target.
-export(float, EXP, 0.0, 2048.0) var min_distance : float = 1.0
+@export_range(0.0, 2048.0, , "exp") var min_distance : float = 1.0 # (float, EXP, 0.0, 2048.0)
 # Softer margin starting from min_distance outwards which pushes Follow gently away from target.
-export(float, EXP, 0.0, 1024.0) var min_distance_push_margin : float = 1.0
+@export_range(0.0, 1024.0, , "exp") var min_distance_push_margin : float = 1.0 # (float, EXP, 0.0, 1024.0)
 # Strength at which Follow will be pushed away if it were at min_distance away.
-export(float, EXP, 0.0, 100.0) var min_distance_push_strength : float = 10.0
+@export_range(0.0, 100.0, , "exp") var min_distance_push_strength : float = 10.0 # (float, EXP, 0.0, 100.0)
 # How pushing strength will lessen when approaching end of margin.
-export(float, EASE) var min_distance_push_easing : float = 2.0
+@export_exp_easing var min_distance_push_easing : float = 2.0 # (float, EASE)
 
 # Distance that Follow isn't allowed to go any farther away from target.
-export(float, EXP, 0.0, 2048.0) var max_distance : float = 3.0
+@export_range(0.0, 2048.0, , "exp") var max_distance : float = 3.0 # (float, EXP, 0.0, 2048.0)
 # Softer margin starting from max_distance inwards which pulls Follow gently towards target.
-export(float, EXP, 0.0, 1024.0) var max_distance_push_margin : float = 1.0
+@export_range(0.0, 1024.0, , "exp") var max_distance_push_margin : float = 1.0 # (float, EXP, 0.0, 1024.0)
 # Strength at which Follow will be pulled if it were at max_distance away.
-export(float, EXP, 0.0, 100.0) var max_distance_push_strength : float = 10.0
+@export_range(0.0, 100.0, , "exp") var max_distance_push_strength : float = 10.0 # (float, EXP, 0.0, 100.0)
 # How pushing strength will lessen when approaching end of margin.
-export(float, EASE) var max_distance_push_easing : float = 2.0
+@export_exp_easing var max_distance_push_easing : float = 2.0 # (float, EASE)
 
 # Don't affect axes defined by bit mask.
 # Bit 0b001: X axis
 # Bit 0b010: Y axis
 # Bit 0b100: Z axis
-export(int, FLAGS, "X", "Y", "Z") var lock_axes : int = 0
+@export_flags("X","Y","Z") var lock_axes : int = 0 # (int, FLAGS, "X", "Y", "Z")
 
 
 func _ready() -> void:
-	if target_path:
+	if target_path != null and !target_path.is_empty():
 		target = get_node(target_path)
 
 func _physics_process(delta : float):
 	# _ready() doesn't get called in-editor so set target every frame for better experience.
 	# In-game however, other scripts may set target directly, so we shouldn't override those.
-	if Engine.editor_hint and target_path:
+	if Engine.is_editor_hint() and target_path != null and !target_path.is_empty():
 		target = get_node(target_path)
 	
 	if is_instance_valid(target):
@@ -80,5 +80,5 @@ func _physics_process(delta : float):
 		global_transform.origin = new_position
 
 func _process(_delta: float) -> void:
-	if Engine.editor_hint:
-		update_gizmo()
+	if Engine.is_editor_hint():
+		update_gizmos()

--- a/addons/virtualcamera/TransformModifiers/Gizmos/FollowGizmoPlugin.gd
+++ b/addons/virtualcamera/TransformModifiers/Gizmos/FollowGizmoPlugin.gd
@@ -1,6 +1,6 @@
-extends EditorSpatialGizmoPlugin
+extends EditorNode3DGizmoPlugin
 
-func has_gizmo(spatial: Spatial) -> bool:
+func _has_gizmo(spatial: Node3D) -> bool:
 	return spatial is Follow
 
 func _init():
@@ -8,18 +8,18 @@ func _init():
 	create_material("billboard", Color(0.2, 0.4, 1), true)
 	create_handle_material("handles")
 
-func get_name() -> String:
+func _get_gizmo_name() -> String:
 	return "Follow"
-
-func redraw(gizmo: EditorSpatialGizmo) -> void:
+	
+func _redraw(gizmo: EditorNode3DGizmo) -> void:
 	gizmo.clear()
 	
-	var target : Follow = gizmo.get_spatial_node()
+	var target : Follow = gizmo.get_node_3d()
 	var lines : Array = []
 	
 	if target.lock_axes == 0b000:
 		_add_distance_circles(lines, target, Vector3.FORWARD)
-		gizmo.add_lines(PoolVector3Array(lines), get_material("billboard", gizmo), true)
+		gizmo.add_lines(PackedVector3Array(lines), get_material("billboard", gizmo), true)
 	else:
 		if (not target.lock_axes & 0b100) and (not target.lock_axes & 0b010):
 			_add_distance_circles(lines, target, Vector3.RIGHT)
@@ -38,7 +38,7 @@ func redraw(gizmo: EditorSpatialGizmo) -> void:
 			_add_distance_lines(lines, target, Vector3.FORWARD)
 			_add_distance_lines(lines, target, Vector3.BACK)
 		
-		gizmo.add_lines(PoolVector3Array(lines), get_material("main", gizmo))
+		gizmo.add_lines(PackedVector3Array(lines), get_material("main", gizmo))
 
 func _add_distance_circles(lines : Array, target : Follow, normal : Vector3):
 	_add_circle(lines, Vector3.ZERO, target.min_distance, normal)
@@ -63,8 +63,8 @@ func _add_circle(lines : Array, offset : Vector3, radius : float, normal : Vecto
 	var vertex_angle = TAU / vertices
 	
 	for i in vertices:
-		lines.append(Quat(normal, vertex_angle * i) * vertex_pos + offset)
-		lines.append(Quat(normal, vertex_angle * (i + 1)) * vertex_pos + offset)
+		lines.append(Quaternion(normal, vertex_angle * i) * vertex_pos + offset)
+		lines.append(Quaternion(normal, vertex_angle * (i + 1)) * vertex_pos + offset)
 
 func _add_dashed_circle(lines : Array, offset : Vector3, radius : float, normal : Vector3 = Vector3.UP, segment_length : float = .3):
 	if radius <= 0:
@@ -76,7 +76,7 @@ func _add_dashed_circle(lines : Array, offset : Vector3, radius : float, normal 
 	var vertex_angle = TAU / vertices
 	
 	for i in range(0, vertices, 1):
-		lines.append(Quat(normal, vertex_angle * i) * vertex_pos + offset)
+		lines.append(Quaternion(normal, vertex_angle * i) * vertex_pos + offset)
 
 func _add_dashed_line(lines : Array, from : Vector3, to : Vector3, segment_length : float = .1) -> void:
 	var direction : Vector3 = to - from

--- a/addons/virtualcamera/TransformModifiers/LookAt.gd
+++ b/addons/virtualcamera/TransformModifiers/LookAt.gd
@@ -1,13 +1,13 @@
-tool
+@tool
 extends "res://addons/virtualcamera/TransformModifiers/TransformModifier.gd"
 
 class_name LookAt
 
-export var look_at_target : NodePath
-export var look_at_lerp_t : float = 1.0
-export var look_at_offset : Vector3 = Vector3.ZERO
+@export var look_at_target : NodePath
+@export var look_at_lerp_t : float = 1.0
+@export var look_at_offset : Vector3 = Vector3.ZERO
 
-var rotation_internal : Quat = Quat.IDENTITY
+var rotation_internal : Quaternion = Quaternion.IDENTITY
 
 func has_look_at_target() -> bool:
 	return not look_at_target.is_empty()
@@ -20,7 +20,7 @@ func _physics_process(delta : float):
 			if target_dist.length_squared() > 0 and target_dist.normalized().abs() != Vector3.UP:
 				rotation = rotation_internal.get_euler()
 				look_at(target.global_transform.origin + self.look_at_offset, Vector3.UP)
-				rotation_internal = rotation_internal.slerp(Quat(rotation), self.look_at_lerp_t)
+				rotation_internal = rotation_internal.slerp(Quaternion.from_euler(rotation), self.look_at_lerp_t)
 				rotation = rotation_internal.get_euler()
 		else:
 			self.look_at_target = NodePath()

--- a/addons/virtualcamera/TransformModifiers/LookAtGroup.gd
+++ b/addons/virtualcamera/TransformModifiers/LookAtGroup.gd
@@ -1,14 +1,14 @@
-tool
+@tool
 extends "res://addons/virtualcamera/TransformModifiers/TransformModifier.gd"
 
 class_name LookAtGroup
 
-export(Array, NodePath) var look_at_targets : Array
-export(Array, Vector3) var target_weights : Array
-export var look_at_lerp_t : float = 1.0
-export var look_at_offset : Vector3 = Vector3.ZERO
+@export var look_at_targets : Array[NodePath] # (Array, NodePath)
+@export var target_weights : Array[Vector3] # (Array, Vector3)
+@export var look_at_lerp_t : float = 1.0
+@export var look_at_offset : Vector3 = Vector3.ZERO
 
-var rotation_internal : Quat = Quat.IDENTITY
+var rotation_internal : Quaternion = Quaternion.IDENTITY
 
 func has_look_at_target() -> bool:
 	return look_at_targets.size() > 0
@@ -16,11 +16,11 @@ func has_look_at_target() -> bool:
 func _physics_process(delta : float):
 	while look_at_targets.size() > target_weights.size():
 		target_weights.append(Vector3.ONE)
-		property_list_changed_notify()
+		notify_property_list_changed()
 	if look_at_targets.size() < target_weights.size():
 		target_weights.resize(look_at_targets.size())
-		property_list_changed_notify()
-	if !Engine.editor_hint:
+		notify_property_list_changed()
+	if !Engine.is_editor_hint():
 		if has_look_at_target():
 			var to_remove = []
 			var total_weight = Vector3.ZERO
@@ -34,10 +34,10 @@ func _physics_process(delta : float):
 				else:
 					to_remove.append(i)
 			for i in to_remove:
-				look_at_targets.remove(i)
+				look_at_targets.remove_at(i)
 			var target_dist = global_transform.origin - target_position
 			if target_dist.length_squared() > 0 and target_dist.normalized().abs() != Vector3.UP:
 				rotation = rotation_internal.get_euler()
 				look_at(target_position + self.look_at_offset, Vector3.UP)
-				rotation_internal = rotation_internal.slerp(Quat(rotation), self.look_at_lerp_t)
+				rotation_internal = rotation_internal.slerp(Quaternion.from_euler(rotation), self.look_at_lerp_t)
 				rotation = rotation_internal.get_euler()

--- a/addons/virtualcamera/TransformModifiers/Shake.gd
+++ b/addons/virtualcamera/TransformModifiers/Shake.gd
@@ -1,26 +1,26 @@
-tool
+@tool
 extends "res://addons/virtualcamera/TransformModifiers/TransformModifier.gd"
 
 class_name Shake
 
-export var noise : OpenSimplexNoise
-export var speed : float = 1.0
+@export var noise : FastNoiseLite
+@export var speed : float = 1.0
 
-export(float, 0, 1) var intensity : float = 1.0
-export(float, EASE) var intensity_curve : float = 2.0
-export var intensity_decrease_rate : float = 0.0
+@export_range(0,1) var intensity : float = 1.0 # (float, 0, 1)
+@export_exp_easing var intensity_curve : float = 2.0 # (float, EASE)
+@export var intensity_decrease_rate : float = 0.0
 
-export var translation_strength : Vector3 = Vector3.ZERO
-export var rotation_strength : Vector3 = Vector3.ZERO
+@export var translation_strength : Vector3 = Vector3.ZERO
+@export var rotation_strength : Vector3 = Vector3.ZERO
 
 var time : float = 0.0
 
 func _ready():
 	if not noise:
-		noise = OpenSimplexNoise.new()
+		noise = FastNoiseLite.new()
 		noise.seed = get_instance_id()
-		noise.octaves = 4
-		noise.persistence = 0.8
+		noise.fractal_octaves = 4
+		noise.fractal_gain = 0.8
 
 const DEG2RAD = TAU / 360
 
@@ -28,12 +28,12 @@ func _physics_process(delta : float):
 	if noise:
 		time += delta * speed * 100
 		
-		if not Engine.editor_hint:
+		if not Engine.is_editor_hint():
 			intensity = max(0, intensity - intensity_decrease_rate * delta)
 		var amplitude = ease(intensity, intensity_curve)
 		
-		translation = Vector3(noise.get_noise_1d(time), noise.get_noise_1d(time - 10000), noise.get_noise_1d(time - 20000))
-		translation *= translation_strength * amplitude
+		position = Vector3(noise.get_noise_1d(time), noise.get_noise_1d(time - 10000), noise.get_noise_1d(time - 20000))
+		position *= translation_strength * amplitude
 		
 		rotation = Vector3(noise.get_noise_1d(time - 30000), noise.get_noise_1d(time - 40000), noise.get_noise_1d(time - 50000))
 		rotation *= rotation_strength * DEG2RAD * amplitude

--- a/addons/virtualcamera/TransformModifiers/SnapToPath.gd
+++ b/addons/virtualcamera/TransformModifiers/SnapToPath.gd
@@ -1,21 +1,21 @@
-tool
+@tool
 extends TransformModifier
 
 # This modifier takes the current position and snaps it to predefined path. Use for camera dolly -like movement.
 class_name SnapToPath
 
-export(NodePath) var target_path : NodePath
-export(float, 0.0, 1.0) var lerp_t = 1.0
-export var is_path_closed : bool = false
+@export var target_path: NodePath
+@export_range(0.0,1.0) var lerp_t : float = 1.0
+@export var is_path_closed : bool = false
 var current_offset : float = -1 # -1 = snap
 
 func _physics_process(delta : float):
-	var target_path_node : Path = get_node_or_null(self.target_path) as Path
+	var target_path_node : Path3D = get_node_or_null(self.target_path) as Path3D
 	if target_path_node != null and target_path_node.curve != null:
 		var initial_position : Vector3
-		if get_parent() as Spatial:
+		if get_parent() as Node3D:
 			initial_position = get_parent().global_transform.origin
-		initial_position = target_path_node.global_transform.xform_inv(initial_position)
+		initial_position = (initial_position) * target_path_node.global_transform
 		var new_offset : float = target_path_node.curve.get_closest_offset(initial_position)
 		if self.current_offset < 0:
 			self.current_offset = new_offset
@@ -29,4 +29,4 @@ func _physics_process(delta : float):
 				elif new_offset - self.current_offset < curve_length * -.5:
 					new_offset += curve_length
 				self.current_offset = fposmod(lerp(self.current_offset, new_offset, self.lerp_t), curve_length)
-		global_transform.origin = target_path_node.global_transform.xform(target_path_node.curve.interpolate_baked(self.current_offset))
+		global_transform.origin = target_path_node.global_transform * (target_path_node.curve.interpolate_baked(self.current_offset))

--- a/addons/virtualcamera/TransformModifiers/TransformModifier.gd
+++ b/addons/virtualcamera/TransformModifiers/TransformModifier.gd
@@ -1,3 +1,3 @@
-extends Spatial
-
-class_name TransformModifier, "res://addons/virtualcamera/TransformModifiers/TransformModifier.svg"
+@icon("res://addons/virtualcamera/TransformModifiers/TransformModifier.svg")
+class_name TransformModifier
+extends Node3D

--- a/addons/virtualcamera/TransformModifiers/UniformMovement/UniformRotation.gd
+++ b/addons/virtualcamera/TransformModifiers/UniformMovement/UniformRotation.gd
@@ -2,7 +2,7 @@ extends "res://addons/virtualcamera/TransformModifiers/UniformMovement/UniformMo
 
 class_name UniformRotation
 
-export var degrees_per_second : Vector3 = Vector3.ZERO
+@export var degrees_per_second : Vector3 = Vector3.ZERO
 
 func _physics_process(delta : float):
-	rotation += deg2rad(1.0) * degrees_per_second * delta
+	rotation += deg_to_rad(1.0) * degrees_per_second * delta

--- a/addons/virtualcamera/TransformModifiers/UniformMovement/UniformTranslation.gd
+++ b/addons/virtualcamera/TransformModifiers/UniformMovement/UniformTranslation.gd
@@ -2,7 +2,7 @@ extends "res://addons/virtualcamera/TransformModifiers/UniformMovement/UniformMo
 
 class_name UniformTranslation
 
-export var translation_per_second : Vector3 = Vector3.ZERO
+@export var translation_per_second : Vector3 = Vector3.ZERO
 
 func _physics_process(delta : float):
-	translation += translation_per_second * delta
+	position += translation_per_second * delta

--- a/addons/virtualcamera/TransformModifiers/UserInput/Orbiter.gd
+++ b/addons/virtualcamera/TransformModifiers/UserInput/Orbiter.gd
@@ -1,26 +1,26 @@
-tool
+@tool
 extends "res://addons/virtualcamera/TransformModifiers/UserInput/UserInput.gd"
 
 class_name Orbiter
 
-export var positive_yaw_mapped_input : String
-export var negative_yaw_mapped_input : String
-export var positive_pitch_mapped_input : String
-export var negative_pitch_mapped_input : String
-export var mouse_input : bool = true
-export var mouse_sensitivity : float = 0.25
-export var rotation_speed : Vector2 = Vector2(1, 1)
-export(float, 0.0, 1.0) var lerp_speed : float = 1.0
+@export var positive_yaw_mapped_input : String
+@export var negative_yaw_mapped_input : String
+@export var positive_pitch_mapped_input : String
+@export var negative_pitch_mapped_input : String
+@export var mouse_input : bool = true
+@export var mouse_sensitivity : float = 0.25
+@export var rotation_speed : Vector2 = Vector2(1, 1)
+@export_range(0.0,1.0) var lerp_speed : float = 1.0 # (float, 0.0, 1.0)
 
-export var orbit_radii : Vector3 = Vector3(1, 3, 1)
-export var orbit_heights : Vector3 = Vector3(2, 1, 0)
+@export var orbit_radii : Vector3 = Vector3(1, 3, 1)
+@export var orbit_heights : Vector3 = Vector3(2, 1, 0)
 
-export var top_offset : Vector2 = Vector2.ZERO
-export var middle_offset : Vector2 = Vector2.ZERO
-export var bottom_offset : Vector2 = Vector2.ZERO
+@export var top_offset : Vector2 = Vector2.ZERO
+@export var middle_offset : Vector2 = Vector2.ZERO
+@export var bottom_offset : Vector2 = Vector2.ZERO
 
-onready var input_rotation : Vector2 = Vector2.ZERO
-onready var lerped_input_rotation : Vector2 = Vector2.ZERO
+@onready var input_rotation : Vector2 = Vector2.ZERO
+@onready var lerped_input_rotation : Vector2 = Vector2.ZERO
 
 func _ready():
 	update_translation()
@@ -37,43 +37,43 @@ func _physics_process(delta : float):
 		orbit_radii.y = 0.0
 	if orbit_radii.z < 0.0:
 		orbit_radii.z = 0.0
-	if Engine.editor_hint:
-		translation = Vector3.ZERO
+	if Engine.is_editor_hint():
+		position = Vector3.ZERO
 	else:
 		var yaw_axis = 0.0
-		if !negative_yaw_mapped_input.empty():
+		if !negative_yaw_mapped_input.is_empty():
 			yaw_axis -= Input.get_action_strength(negative_yaw_mapped_input)
-		if !positive_yaw_mapped_input.empty():
+		if !positive_yaw_mapped_input.is_empty():
 			yaw_axis += Input.get_action_strength(positive_yaw_mapped_input)
 		input_rotation.x += yaw_axis * rotation_speed.x * 5
 		var pitch_axis = 0.0
-		if !negative_pitch_mapped_input.empty():
+		if !negative_pitch_mapped_input.is_empty():
 			pitch_axis -= Input.get_action_strength(negative_pitch_mapped_input)
-		if !positive_pitch_mapped_input.empty():
+		if !positive_pitch_mapped_input.is_empty():
 			pitch_axis += Input.get_action_strength(positive_pitch_mapped_input)
 		input_rotation.y += pitch_axis * rotation_speed.y * 5
 		
 		input_rotation.x = wrapf(input_rotation.x, -180, 180)
 		input_rotation.y = clamp(input_rotation.y, -90, 90)
-		lerped_input_rotation.x = rad2deg(lerp_angle(deg2rad(lerped_input_rotation.x), deg2rad(input_rotation.x), lerp_speed))
+		lerped_input_rotation.x = rad_to_deg(lerp_angle(deg_to_rad(lerped_input_rotation.x), deg_to_rad(input_rotation.x), lerp_speed))
 		lerped_input_rotation.y = lerp(lerped_input_rotation.y, input_rotation.y, lerp_speed)
 		update_translation()
 
 func _process(delta : float):
-	if Engine.editor_hint:
+	if Engine.is_editor_hint():
 		rebuild_geom()
 
 func update_translation():
 	var pitch = lerped_input_rotation.y / 90
-	var yaw = deg2rad(lerped_input_rotation.x)
-	var r = Quat(Vector3.UP, yaw)
+	var yaw = deg_to_rad(lerped_input_rotation.x)
+	var r = Quaternion(Vector3.UP, yaw)
 	var a = Vector3.UP * orbit_heights.x + r * Vector3.BACK * orbit_radii.x + Vector3(top_offset.x, 0, top_offset.y)
 	var b = Vector3.UP * orbit_heights.y + r * Vector3.BACK * orbit_radii.y + Vector3(middle_offset.x, 0, middle_offset.y)
 	var c = Vector3.UP * orbit_heights.z + r * Vector3.BACK * orbit_radii.z + Vector3(bottom_offset.x, 0, bottom_offset.y)
 	if pitch > 0:
-		translation = calculate_curve(c, b, a, a, pitch)
+		position = calculate_curve(c, b, a, a, pitch)
 	else:
-		translation = calculate_curve(a, b, c, c, abs(pitch))
+		position = calculate_curve(a, b, c, c, abs(pitch))
 
 # Catmull-Rom Spline
 func calculate_curve(a : Vector3, b : Vector3, c : Vector3, d : Vector3, t : float):
@@ -90,50 +90,54 @@ func calculate_curve(a : Vector3, b : Vector3, c : Vector3, d : Vector3, t : flo
 	return result * 0.5
 
 # Gizmos
-var geom : ImmediateGeometry
+var geom : ImmediateMesh
+var geomNode : MeshInstance3D
 const color = Color(0.2, 0.4, 1)
 func instantiate_geom():
 	if Engine.is_editor_hint():
 		if geom == null:
-			geom = get_node_or_null("geom")
-			if geom == null:
-				geom = ImmediateGeometry.new()
-				geom.set_name("geom")
-				add_child(geom)
+			geom = ImmediateMesh.new()
+		if geomNode == null:
+			geomNode = get_node_or_null("geom")
+			if geomNode == null:
+				geomNode = MeshInstance3D.new()
+				geomNode.set_name("geom")
+				add_child(geomNode)
+				geomNode.mesh = geom
 
 func add_circle_to_geom(radius : float, offset : Vector3 = Vector3.ZERO, vertices : int = 40, normal : Vector3 = Vector3.UP):
-	geom.begin(Mesh.PRIMITIVE_LINE_LOOP)
-	geom.set_color(color)
+	geom.surface_begin(Mesh.PRIMITIVE_LINE_STRIP) # PRIMITIVE_LINE_LOOP no longer exists
+	geom.surface_set_color(color)
 	var vertex_pos = Vector3.BACK * radius
 	var vertex_angle = (PI * 2) / vertices
 	for i in vertices:
-		geom.add_vertex(Quat(normal, vertex_angle * i) * vertex_pos + offset)
-	geom.end()
+		geom.surface_add_vertex(Quaternion(normal, vertex_angle * i) * vertex_pos + offset)
+	geom.surface_end()
 
 func add_curve_to_geom(a : Vector3, b : Vector3, c : Vector3, vertices : int = 40):
-	geom.begin(Mesh.PRIMITIVE_LINE_STRIP)
-	geom.set_color(color)
+	geom.surface_begin(Mesh.PRIMITIVE_LINE_STRIP)
+	geom.surface_set_color(color)
 	vertices -= 3
 	var half_vertices = vertices / 2
 	var step = 1.0 / half_vertices
-	geom.add_vertex(a)
+	geom.surface_add_vertex(a)
 	for i in range(1, half_vertices):
 		var vertex = calculate_curve(a, a, b, c, step * i)
-		geom.add_vertex(vertex)
-	geom.add_vertex(b)
+		geom.surface_add_vertex(vertex)
+	geom.surface_add_vertex(b)
 	for i in range(1, half_vertices):
 		var vertex = calculate_curve(a, b, c, c, step * i)
-		geom.add_vertex(vertex)
-	geom.add_vertex(c)
-	geom.end()
+		geom.surface_add_vertex(vertex)
+	geom.surface_add_vertex(c)
+	geom.surface_end()
 
 func init_geom():
 	if Engine.is_editor_hint() :
-		geom.clear()
-		var mat = SpatialMaterial.new()
+		geom.clear_surfaces()
+		var mat = StandardMaterial3D.new()
 		mat.flags_unshaded = true
 		mat.vertex_color_use_as_albedo = true
-		geom.material_override = mat
+		geomNode.material_override = mat
 		add_circle_to_geom(orbit_radii.x, Vector3(top_offset.x, orbit_heights.x, top_offset.y))
 		add_circle_to_geom(orbit_radii.y, Vector3(middle_offset.x, orbit_heights.y, middle_offset.y))
 		add_circle_to_geom(orbit_radii.z, Vector3(bottom_offset.x, orbit_heights.z, bottom_offset.y))

--- a/addons/virtualcamera/VCameraBrain.gd
+++ b/addons/virtualcamera/VCameraBrain.gd
@@ -1,12 +1,13 @@
-tool
-extends Camera
+@tool
+@icon("res://addons/virtualcamera/VCameraBrain.svg")
+class_name VCameraBrain
+extends Camera3D
 
-class_name VCameraBrain, "res://addons/virtualcamera/VCameraBrain.svg"
 
-export var target_group : String = "vcamera"
+@export var target_group : String = "vcamera"
 var last_active_vcamera : VCamera = null
 var transition_time : float = 0.0
-var transition_start_transform : Transform
+var transition_start_transform : Transform3D
 var transition_start_fov : float
 var transition_start_near : float
 var transition_start_far : float

--- a/addons/virtualcamera/VCameraBrain.svg.import
+++ b/addons/virtualcamera/VCameraBrain.svg.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/VCameraBrain.svg-f140520dcbb71ebc9549718853b1c470.stex"
+type="CompressedTexture2D"
+uid="uid://b376t6a6guwnh"
+path="res://.godot/imported/VCameraBrain.svg-f140520dcbb71ebc9549718853b1c470.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,27 @@ metadata={
 [deps]
 
 source_file="res://addons/virtualcamera/VCameraBrain.svg"
-dest_files=[ "res://.import/VCameraBrain.svg-f140520dcbb71ebc9549718853b1c470.stex" ]
+dest_files=["res://.godot/imported/VCameraBrain.svg-f140520dcbb71ebc9549718853b1c470.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1
 svg/scale=1.0
+editor/scale_with_editor_scale=false
+editor/convert_colors_with_editor_theme=false

--- a/addons/virtualcamera/VCameras/PreviewPlugin/VCameraPreviewPlugin.gd
+++ b/addons/virtualcamera/VCameras/PreviewPlugin/VCameraPreviewPlugin.gd
@@ -1,12 +1,12 @@
-tool
+@tool
 extends Control
 
 signal closing
 
-onready var aspect_option : OptionButton = $VBoxContainer/HBoxContainer/AspectOptionButton
-onready var aspect_container : AspectRatioContainer = $VBoxContainer/AspectRatioContainer
-onready var keep_option : OptionButton = $VBoxContainer/HBoxContainer/KeepOptionButton
-onready var camera : Camera = $VBoxContainer/AspectRatioContainer/ViewportContainer/Viewport/Camera
+@onready var aspect_option : OptionButton = $VBoxContainer/HBoxContainer/AspectOptionButton
+@onready var aspect_container : AspectRatioContainer = $VBoxContainer/AspectRatioContainer
+@onready var keep_option : OptionButton = $VBoxContainer/HBoxContainer/KeepOptionButton
+@onready var camera : Camera3D = $VBoxContainer/AspectRatioContainer/SubViewportContainer/SubViewport/Camera3D
 var target_vcamera : VCamera
 
 var aspect_ratios = [ 
@@ -26,8 +26,9 @@ func _ready() -> void:
 	keep_option.add_item("FOV: Keep Height")
 	keep_option.selected = 1
 	
-	target_vcamera.connect("tree_exited", self, "_on_CloseButton_pressed")
-	name = target_vcamera.name + " Preview"
+	if target_vcamera != null:
+		target_vcamera.connect("tree_exited", Callable(self, "_on_CloseButton_pressed"))
+		name = target_vcamera.name + " Preview"
 
 func _process(_delta: float) -> void:
 	if is_instance_valid(target_vcamera):

--- a/addons/virtualcamera/VCameras/PreviewPlugin/VCameraPreviewPlugin.tscn
+++ b/addons/virtualcamera/VCameras/PreviewPlugin/VCameraPreviewPlugin.tscn
@@ -1,71 +1,73 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=2 format=3 uid="uid://cnkk5kjsmpw05"]
 
-[ext_resource path="res://addons/virtualcamera/VCameras/PreviewPlugin/VCameraPreviewPlugin.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/virtualcamera/VCameras/PreviewPlugin/VCameraPreviewPlugin.gd" id="1"]
 
 [node name="VCamera Preview" type="Control"]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
-margin_right = 1024.0
-margin_bottom = 20.0
-custom_constants/separation = 10
+layout_mode = 2
+theme_override_constants/separation = 10
 
 [node name="AspectOptionButton" type="OptionButton" parent="VBoxContainer/HBoxContainer"]
-margin_right = 140.0
-margin_bottom = 20.0
-text = "16:9 Standard HD"
-items = [ "16:9 Standard HD", null, false, 0, null, "4:3 Standard SD", null, false, 1, null, "9:16 Standard Portrait", null, false, 2, null, "16:9 Split Vertical", null, false, 3, null, "16:9 Split Horizontal", null, false, 4, null ]
+layout_mode = 2
+item_count = 5
 selected = 0
+popup/item_0/text = "16:9 Standard HD"
+popup/item_0/id = 0
+popup/item_1/text = "4:3 Standard SD"
+popup/item_1/id = 1
+popup/item_2/text = "9:16 Standard Portrait"
+popup/item_2/id = 2
+popup/item_3/text = "16:9 Split Vertical"
+popup/item_3/id = 3
+popup/item_4/text = "16:9 Split Horizontal"
+popup/item_4/id = 4
 
 [node name="KeepOptionButton" type="OptionButton" parent="VBoxContainer/HBoxContainer"]
-margin_left = 150.0
-margin_right = 291.0
-margin_bottom = 20.0
-text = "FOV: Keep Height"
-items = [ "FOV: Keep Height", null, false, 0, null, "FOV: Keep Width", null, false, 1, null ]
-selected = 0
+layout_mode = 2
+item_count = 2
+selected = 1
+popup/item_0/text = "FOV: Keep Width"
+popup/item_0/id = 0
+popup/item_1/text = "FOV: Keep Height"
+popup/item_1/id = 1
 
 [node name="Control" type="Control" parent="VBoxContainer/HBoxContainer"]
-margin_left = 301.0
-margin_right = 994.0
-margin_bottom = 20.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="CloseButton" type="Button" parent="VBoxContainer/HBoxContainer"]
-margin_left = 1004.0
-margin_right = 1024.0
-margin_bottom = 20.0
+layout_mode = 2
 text = "X"
 
 [node name="AspectRatioContainer" type="AspectRatioContainer" parent="VBoxContainer"]
-margin_top = 24.0
-margin_right = 1024.0
-margin_bottom = 600.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 ratio = 1.7778
 
-[node name="ViewportContainer" type="ViewportContainer" parent="VBoxContainer/AspectRatioContainer"]
-margin_top = 0.00360107
-margin_right = 1024.0
-margin_bottom = 575.996
+[node name="SubViewportContainer" type="SubViewportContainer" parent="VBoxContainer/AspectRatioContainer"]
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch = true
 
-[node name="Viewport" type="Viewport" parent="VBoxContainer/AspectRatioContainer/ViewportContainer"]
-size = Vector2( 1024, 575 )
+[node name="SubViewport" type="SubViewport" parent="VBoxContainer/AspectRatioContainer/SubViewportContainer"]
 handle_input_locally = false
-render_target_update_mode = 3
-shadow_atlas_size = 1
+size = Vector2i(1089, 613)
+render_target_update_mode = 4
 
-[node name="Camera" type="Camera" parent="VBoxContainer/AspectRatioContainer/ViewportContainer/Viewport"]
+[node name="Camera3D" type="Camera3D" parent="VBoxContainer/AspectRatioContainer/SubViewportContainer/SubViewport"]
 
 [connection signal="item_selected" from="VBoxContainer/HBoxContainer/AspectOptionButton" to="." method="_on_AspectOptionButton_item_selected"]
 [connection signal="item_selected" from="VBoxContainer/HBoxContainer/KeepOptionButton" to="." method="_on_KeepOptionButton_item_selected"]

--- a/addons/virtualcamera/VCameras/VCamera.gd
+++ b/addons/virtualcamera/VCameras/VCamera.gd
@@ -1,85 +1,90 @@
-tool
-extends Spatial
+@tool
+@icon("res://addons/virtualcamera/VCameras/VCamera.svg")
+class_name VCamera
+extends Node3D
 
-class_name VCamera, "res://addons/virtualcamera/VCameras/VCamera.svg"
 
-export(int, 0, 1024) var priority : int = 10
-export var enabled : bool = true
+@export var priority : int = 10 # (int, 0, 1024)
+@export var enabled : bool = true
 
-export var transition_time : float = 1.0
-export(float, EASE) var transition_ease : float = -2.0
+@export var transition_time : float = 1.0
+@export var transition_ease : float = -2.0 # (float, EASE)
 
-export(float, 1, 179) var fov : float = 70.0 setget set_fov
+@export var fov : float = 70.0: set = set_fov
 func set_fov(value : float) -> void:
 	fov = value
-	if Engine.editor_hint:
+	if Engine.is_editor_hint():
 		rebuild_geom()
 
-export(float, EXP, 0.01, 8192) var near : float = 0.05
-export(float, EXP, 0.01, 8192) var far : float = 100.0
+@export var near : float = 0.05 # (float, EXP, 0.01, 8192)
+@export var far : float = 100.0 # (float, EXP, 0.01, 8192)
 
 func _ready():
-	if Engine.editor_hint:
+	if Engine.is_editor_hint():
 		rebuild_geom()
 		set_process_priority(-1000)
 	add_to_group("vcamera", true)
 
 func _process(delta : float):
-	if Engine.editor_hint:
+	if Engine.is_editor_hint():
 		rebuild_geom()
 
 # Gizmos
-var geom : ImmediateGeometry
+var geom : ImmediateMesh
+var geomNode : MeshInstance3D
 const color = Color(0.2, 0.6, 0.2)
 func instantiate_geom():
 	if Engine.is_editor_hint():
 		if geom == null:
-			geom = get_node_or_null("geom")
-			if geom == null:
-				geom = ImmediateGeometry.new()
-				geom.set_name("geom")
-				add_child(geom)
+			geom = ImmediateMesh.new()
+		if geomNode == null:
+			geomNode = get_node_or_null("geom")
+			if geomNode == null:
+				geomNode = MeshInstance3D.new()
+				geomNode.set_name("geom")
+				add_child(geomNode)
+				geomNode.mesh = geom
 
 func init_geom():
 	if Engine.is_editor_hint() :
-		geom.clear()
-		var mat = SpatialMaterial.new()
+		geom.clear_surfaces()
+		var mat = StandardMaterial3D.new()
 		mat.flags_unshaded = true
 		mat.vertex_color_use_as_albedo = true
-		var z_len = cos(deg2rad(fov / 2))
-		var xy_len = sin(deg2rad(fov / 2))
-		geom.material_override = mat
+		var z_len = cos(deg_to_rad(fov / 2))
+		var xy_len = sin(deg_to_rad(fov / 2))
+		geomNode.material_override = mat
 		
 		# Cone
-		geom.begin(Mesh.PRIMITIVE_LINES)
-		geom.set_color(color)
-		geom.add_vertex(Vector3(0.0, 0.0, 0.0))
-		geom.add_vertex(Vector3(xy_len, xy_len, -z_len))
-		geom.add_vertex(Vector3(0.0, 0.0, 0.0))
-		geom.add_vertex(Vector3(-xy_len, xy_len, -z_len))
-		geom.add_vertex(Vector3(0.0, 0.0, 0.0))
-		geom.add_vertex(Vector3(-xy_len, -xy_len, -z_len))
-		geom.add_vertex(Vector3(0.0, 0.0, 0.0))
-		geom.add_vertex(Vector3(xy_len, -xy_len, -z_len))
-		geom.end()
+		geom.surface_begin(Mesh.PRIMITIVE_LINES)
+		geom.surface_set_color(color)
+		geom.surface_add_vertex(Vector3(0.0, 0.0, 0.0))
+		geom.surface_add_vertex(Vector3(xy_len, xy_len, -z_len))
+		geom.surface_add_vertex(Vector3(0.0, 0.0, 0.0))
+		geom.surface_add_vertex(Vector3(-xy_len, xy_len, -z_len))
+		geom.surface_add_vertex(Vector3(0.0, 0.0, 0.0))
+		geom.surface_add_vertex(Vector3(-xy_len, -xy_len, -z_len))
+		geom.surface_add_vertex(Vector3(0.0, 0.0, 0.0))
+		geom.surface_add_vertex(Vector3(xy_len, -xy_len, -z_len))
+		geom.surface_end()
 		
 		# Square
-		geom.begin(Mesh.PRIMITIVE_LINE_STRIP)
-		geom.set_color(color)
-		geom.add_vertex(Vector3(xy_len, xy_len, -z_len))
-		geom.add_vertex(Vector3(-xy_len, xy_len, -z_len))
-		geom.add_vertex(Vector3(-xy_len, -xy_len, -z_len))
-		geom.add_vertex(Vector3(xy_len, -xy_len, -z_len))
-		geom.add_vertex(Vector3(xy_len, xy_len, -z_len))
-		geom.end()
+		geom.surface_begin(Mesh.PRIMITIVE_LINE_STRIP)
+		geom.surface_set_color(color)
+		geom.surface_add_vertex(Vector3(xy_len, xy_len, -z_len))
+		geom.surface_add_vertex(Vector3(-xy_len, xy_len, -z_len))
+		geom.surface_add_vertex(Vector3(-xy_len, -xy_len, -z_len))
+		geom.surface_add_vertex(Vector3(xy_len, -xy_len, -z_len))
+		geom.surface_add_vertex(Vector3(xy_len, xy_len, -z_len))
+		geom.surface_end()
 		
 		# Up pointer
-		geom.begin(Mesh.PRIMITIVE_LINE_STRIP)
-		geom.set_color(color)
-		geom.add_vertex(Vector3(xy_len * -0.25, xy_len, -z_len))
-		geom.add_vertex(Vector3(0.0, xy_len * 1.5, -z_len))
-		geom.add_vertex(Vector3(xy_len * 0.25, xy_len, -z_len))
-		geom.end()
+		geom.surface_begin(Mesh.PRIMITIVE_LINE_STRIP)
+		geom.surface_set_color(color)
+		geom.surface_add_vertex(Vector3(xy_len * -0.25, xy_len, -z_len))
+		geom.surface_add_vertex(Vector3(0.0, xy_len * 1.5, -z_len))
+		geom.surface_add_vertex(Vector3(xy_len * 0.25, xy_len, -z_len))
+		geom.surface_end()
 
 func rebuild_geom():
 	instantiate_geom()

--- a/addons/virtualcamera/VCameras/VCamera.svg.import
+++ b/addons/virtualcamera/VCameras/VCamera.svg.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/VCamera.svg-c1aa45ec6d567f8a950b5c270f369d75.stex"
+type="CompressedTexture2D"
+uid="uid://c6fyarjkkw43n"
+path="res://.godot/imported/VCamera.svg-c1aa45ec6d567f8a950b5c270f369d75.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,27 @@ metadata={
 [deps]
 
 source_file="res://addons/virtualcamera/VCameras/VCamera.svg"
-dest_files=[ "res://.import/VCamera.svg-c1aa45ec6d567f8a950b5c270f369d75.stex" ]
+dest_files=["res://.godot/imported/VCamera.svg-c1aa45ec6d567f8a950b5c270f369d75.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1
 svg/scale=1.0
+editor/scale_with_editor_scale=false
+editor/convert_colors_with_editor_theme=false

--- a/addons/virtualcamera/VCameras/VCameraTriggerAction.gd
+++ b/addons/virtualcamera/VCameras/VCameraTriggerAction.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends Node
 
 class_name VCameraTriggerAction
@@ -15,30 +15,30 @@ enum Action {
 var target_vcamera : NodePath
 var filter_objects_by_group : String
 
-var on_enter_action : int = Action.ENABLE setget set_on_enter_action
+var on_enter_action : int = Action.ENABLE: set = set_on_enter_action
 func set_on_enter_action(value : int) -> void:
 	on_enter_action = value
-	property_list_changed_notify()
+	notify_property_list_changed()
 
 var on_enter_priority : int = 0
 var on_enter_group : String = ""
 
-var on_exit_action : int = Action.DISABLE setget set_on_exit_action
+var on_exit_action : int = Action.DISABLE: set = set_on_exit_action
 func set_on_exit_action(value : int) -> void:
 	on_exit_action = value
-	property_list_changed_notify()
+	notify_property_list_changed()
 
 var on_exit_priority : int = 0
 var on_exit_group : String = ""
 
-var _overlapping_count : int = 0 setget _set_overlapping_count
+var _overlapping_count : int = 0: set = _set_overlapping_count
 
 func _ready() -> void:
-	if get_parent() is Area and not Engine.editor_hint:
-		get_parent().connect("area_entered", self, "_on_entered")
-		get_parent().connect("body_entered", self, "_on_entered")
-		get_parent().connect("area_exited", self, "_on_exited")
-		get_parent().connect("body_exited", self, "_on_exited")
+	if get_parent() is Area3D and not Engine.is_editor_hint():
+		get_parent().connect("area_entered", Callable(self, "_on_entered"))
+		get_parent().connect("body_entered", Callable(self, "_on_entered"))
+		get_parent().connect("area_exited", Callable(self, "_on_exited"))
+		get_parent().connect("body_exited", Callable(self, "_on_exited"))
 
 func _on_entered(area) -> void:
 	if filter_objects_by_group and not area.is_in_group(filter_objects_by_group):
@@ -93,8 +93,8 @@ func _get_property_list() -> Array:
 	
 	return gen.properties
 
-func _get_configuration_warning():
-	if get_parent() is Area:
+func _get_configuration_warnings():
+	if get_parent() is Area3D:
 		return ""
 	else:
-		return "VCameraTriggerAction has to be child of Area to be usable.\n\nAction choosen on enter will be executed when first area/body enters parent Area.\nAction choosen on exit will be executed when last area/body leaves parent Area."
+		return "VCameraTriggerAction has to be child of Area3D to be usable.\n\nAction choosen on enter will be executed when first area/body enters parent Area3D.\nAction choosen on exit will be executed when last area/body leaves parent Area3D."

--- a/addons/virtualcamera/plugin.gd
+++ b/addons/virtualcamera/plugin.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorPlugin
 
 const VCAMERA_PREVIEW_SCENE = preload("res://addons/virtualcamera/VCameras/PreviewPlugin/VCameraPreviewPlugin.tscn")
@@ -12,19 +12,19 @@ func _enter_tree():
 	var http = HTTPRequest.new()
 	add_child(http)
 	var project_hash = ProjectSettings.get_setting("application/config/name").sha256_text()
-	http.request("https://pluginstats.brycedixon.dev/", [], true, HTTPClient.METHOD_POST, JSON.print({plugin="VCamera", project=project_hash}))
+	http.request("https://pluginstats.brycedixon.dev/", [], HTTPClient.METHOD_POST, JSON.stringify({plugin="VCamera", project=project_hash}))
 	# Usage Tracking
 	
-	add_spatial_gizmo_plugin(follow_gizmo_plugin)
+	add_node_3d_gizmo_plugin(follow_gizmo_plugin)
 
-func handles(object: Object) -> bool:
+func _handles(object: Object) -> bool:
 	return object is VCamera
 
-func edit(object: Object) -> void:
+func _edit(object: Object) -> void:
 	close_vcamera_preview()
-	vcamera_preview = VCAMERA_PREVIEW_SCENE.instance()
+	vcamera_preview = VCAMERA_PREVIEW_SCENE.instantiate()
 	vcamera_preview.target_vcamera = object
-	vcamera_preview.connect("closing", self, "close_vcamera_preview")
+	vcamera_preview.connect("closing", Callable(self, "close_vcamera_preview"))
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_RIGHT_BL, vcamera_preview)
 
 func close_vcamera_preview() -> void:
@@ -34,4 +34,4 @@ func close_vcamera_preview() -> void:
 
 func _exit_tree():
 	close_vcamera_preview()
-	remove_spatial_gizmo_plugin(follow_gizmo_plugin)
+	remove_node_3d_gizmo_plugin(follow_gizmo_plugin)

--- a/addons/virtualcamera/plugin.gd
+++ b/addons/virtualcamera/plugin.gd
@@ -12,7 +12,7 @@ func _enter_tree():
 	var http = HTTPRequest.new()
 	add_child(http)
 	var project_hash = ProjectSettings.get_setting("application/config/name").sha256_text()
-	http.request("https://pluginstats.brycedixon.dev/", [], HTTPClient.METHOD_POST, JSON.stringify({plugin="VCamera", project=project_hash}))
+	#http.request("https://pluginstats.brycedixon.dev/", [], HTTPClient.METHOD_POST, JSON.stringify({plugin="VCamera", project=project_hash}))
 	# Usage Tracking
 	
 	add_node_3d_gizmo_plugin(follow_gizmo_plugin)


### PR DESCRIPTION
This PR makes the VCamera plugin work in Godot 4. All of the scripts and example scenes were first run through Godot's own automatic conversion, then manually edited to make sure the plugin runs without errors.

- All Export annotations were changed to their new format counterparts
- Functions and properties that no longer exist in version 4 were replaced with their closest alternatives

The behavior of the plugin was not changed, verified by comparing the example scenes between the current version of the plugin running in Godot 3.5.2 and this ported version running on 4.0.2, which both produced seemingly identical output.

(I'm aware the plugin was originally made for 3.4, so if anything broke between 3.4 and 3.5, at the very least it remains broken in exactly the same way in 4.0 with this port.)